### PR TITLE
#14295 (3-1-5.p5): Fix build error with GCC 4.7.x on Solaris due to overloaded floor() and log10().

=== singular-3-1-5.p5 (Leif Leonhardy, March 18th 2013) ===
 * #14295: Singular fails to build with GCC 4.7.x on Solaris.
   On Solaris, with `__cplusplus

### DIFF
--- a/build/pkgs/singular/SPKG.txt
+++ b/build/pkgs/singular/SPKG.txt
@@ -58,6 +58,9 @@ Several patches are applied.
    that fixes one memory corruption (writing out of bound).
  * cygwin-makefile.patch: simple fix for Cygwin, see
    http://www.singular.uni-kl.de:8002/trac/ticket/476/
+ * sage_trac_14295.patch: Fix for GCC 4.7.x on Solaris; see
+   http://trac.sagemath.org/sage_trac/ticket/14295 and the changelog
+   entry for singular-3-1-5.p5 below.
 
 Other notes
  * The option '--without-dynamic-kernel' is used on *all*
@@ -84,6 +87,15 @@ Other notes
    for easier debugging of memory corruptions.
 
 == ChangeLog ==
+
+=== singular-3-1-5.p5 (Leif Leonhardy, March 18th 2013) ===
+ * #14295: Singular fails to build with GCC 4.7.x on Solaris.
+   On Solaris, with `__cplusplus >= 199711L`, `floor()` and `log10()` are
+   overloaded functions which get pulled into the global namespace,
+   such that calling them with an `int` gets ambiguous.
+   Patch `kernel/bigintmat.cc` (`patches/sage_trac_14295.patch`)
+   to cast parameters to `floor()` and `log10()` from `int` to
+   `double`, making the calls unambiguous.
 
 === singular-3-1-5.p4 (Jean-Pierre Flori, 12 February 2013) ===
  * Trac #14033: prevent Singular from always linking to ncurses on

--- a/build/pkgs/singular/patches/sage_trac_14295.patch
+++ b/build/pkgs/singular/patches/sage_trac_14295.patch
@@ -1,0 +1,29 @@
+--- src/kernel/bigintmat.cc	2012-06-20 17:00:07.000000000 +0200
++++ src/kernel/bigintmat.cc	2013-03-18 16:18:26.281905612 +0100
+@@ -344,7 +344,7 @@
+     int index = cols*i+j;
+     if ((a[index] > sndlong) && (a[index] < l))
+     {
+-      int min = floor(log10(cols))+floor(log10(rows))+5;
++      int min = floor(log10((double)cols))+floor(log10((double)rows))+5;
+       if ((a[index] < min) && (min < l))
+         sndlong = min;
+       else
+@@ -353,7 +353,7 @@
+   }
+   if (sndlong == 0)
+   {
+-    int min = floor(log10(cols))+floor(log10(rows))+5;
++    int min = floor(log10((double)cols))+floor(log10((double)rows))+5;
+     if (min < l)
+       sndlong = min;
+     else
+@@ -424,7 +424,7 @@
+       if (nl > colwid[cj])
+       {
+         StringSetS("");
+-        int ci = floor(i/col);
++        int ci = floor((double)(i/col)); // actually the same as ci = i/col
+         StringAppend("[%d,%d]", ci+1, cj+1);
+         char *tmp = StringAppendS("");
+         char * ph = omStrDup(tmp);


### PR DESCRIPTION
PR for issues #14295, #14295
