### PR TITLE
Cannot import sage.libs.lcalc.lcalc_Lfunction

### DIFF
--- a/build/pkgs/lcalc/SPKG.txt
+++ b/build/pkgs/lcalc/SPKG.txt
@@ -92,6 +92,11 @@ http://code.google.com/p/l-calc/
 
 == Changelog ==
 
+=== lcalc-1.23.p11 (Jean-Pierre Flori, 8 August 2012) ===
+ * #13351: modify Makefile to define binaries and libraries extension
+           according to host system. As a side effect, this let
+           sage.libs.lcalc.lcal_Lfunction be imported on Cygwin.
+
 === lcalc-1.23.p10 (Leif Leonhardy, March 17th 2012) ===
  * #12681: Fix hard-coded 'g++'.
    The (patched) Makefile now uses $(CXX) (which *defaults* to 'g++')

--- a/build/pkgs/lcalc/patches/Makefile.patch
+++ b/build/pkgs/lcalc/patches/Makefile.patch
@@ -1,5 +1,5 @@
---- src/src/Makefile	2009-07-14 20:23:17.000000000 +0200
-+++ src/src/Makefile	2012-03-17 08:16:53.346311160 +0100
+--- src.orig/src/Makefile	2012-08-08 23:21:56.274799100 +0200
++++ src/src/Makefile	2012-08-08 23:21:45.430581000 +0200
 @@ -13,7 +13,7 @@
  # elliptic curve routines. Doing so disables the -e option.
  # g++ with -DINCLUDE_PARI sends a #define INCLUDE_PARI to the preprocessor.
@@ -9,35 +9,37 @@
  #PREPROCESSOR_DEFINE = -DUSE_LONG_DOUBLE
  
  #OPENMP_FLAG = -fopenmp
-@@ -29,7 +29,15 @@
+@@ -29,7 +29,17 @@
  
  OS_NAME := $(shell uname)
  
 -CC = g++
++ifneq (,$(findstring CYGWIN,$(OS_NAME)))
++  OS_NAME := CYGWIN
++endif
++
 +#CC = g++
 +# Note: I've also changed various rules to use $CXX instead of $CC,
 +# since we mostly compile C++, not C, and $CC is by convention
 +# used for the *C* compiler.
-+# I've kept the [name] CCFLAGS though, which we add $CXXFLAGS to.
-+# -leif (03/2012)
 +CC ?= gcc
 +CXX ?= g++
 +
  #cc = /home/mrubinst/local/bin/gcc
  #CC = /home/mrubinst/local/bin/g++
  #LD = /home/mrubinst/local/bin/g++
-@@ -58,9 +66,7 @@
+@@ -58,9 +68,7 @@
     #MACHINE_SPECIFIC_FLAGS = -mpowerpc -mpowerpc64 -m64
  endif
  
 -CCFLAGS =  -Wa,-W -O3 $(OPENMP_FLAG) -Wno-deprecated $(PREPROCESSOR_DEFINE) $(MACHINE_SPECIFIC_FLAGS) $(EXTRA)
 -#CCFLAGS =  -Wa,-W -O3 $(OPENMP_FLAG)  $(PREPROCESSOR_DEFINE) $(MACHINE_SPECIFIC_FLAGS) $(EXTRA)
 -#CCFLAGS =  -Wa,-W -O2 -fno-exceptions -Wno-deprecated $(PREPROCESSOR_DEFINE) $(MACHINE_SPECIFIC_FLAGS) $(EXTRA)
-+CCFLAGS =  $(CXXFLAGS) -O3  $(OPENMP_FLAG)  $(PREPROCESSOR_DEFINE) $(MACHINE_SPECIFIC_FLAGS) $(EXTRA)
++CXXFLAGS := -O3 $(OPENMP_FLAG) $(PREPROCESSOR_DEFINE) $(MACHINE_SPECIFIC_FLAGS) $(EXTRA) $(CXXFLAGS)
  
  #warning- O2 doesn't help with -DUSE_LONG_DOUBLE on mac, and actually seems to hurt, making runtime longer
  #by a factor of 1.5
-@@ -68,12 +74,12 @@
+@@ -68,12 +76,12 @@
  
  ifeq ($(PARI_DEFINE),-DINCLUDE_PARI)
      #location of pari.h.
@@ -52,7 +54,7 @@
  else
      #supplied as a dummy so as to avoid more ifeq's below
      LOCATION_PARI_H = .
-@@ -88,26 +94,12 @@
+@@ -88,26 +96,12 @@
  #For Mac os x we omit shared library options
  
  ifeq ($(OS_NAME),Darwin)
@@ -76,20 +78,39 @@
 -else
 -    LDFLAGS = $(LDFLAGS2)
 -endif
-+LDFLAGS = -L$(LOCATION_PARI_LIBRARY) -lpari -lgmp
++LDFLAGS := -L$(LOCATION_PARI_LIBRARY) -lpari -lgmp $(LDFLAGS)
  
  
  
-@@ -129,7 +121,7 @@
+@@ -129,47 +123,64 @@
  #become clear which libraries the computer can find.
  
  
 -INSTALL_DIR= /usr/local
 +INSTALL_DIR ?= /usr/local
++
++#binary and library files extensions
++LIBEXT := .so
++EXEEXT :=
++
++ifeq ($(OS_NAME),Darwin)
++    LIBEXT := .dylib
++    EXEEXT :=
++endif
++
++ifeq ($(OS_NAME),CYGWIN)
++    LIBEXT := .dll
++    EXEEXT := .exe
++endif
  
  #object files for the libLfunction library
  OBJ_L = Lglobals.o Lgamma.o Lriemannsiegel.o Lriemannsiegel_blfi.o Ldokchitser.o
-@@ -140,34 +132,37 @@
+ 
+ #object files for the command line program
+-OBJ2=$(OBJ_L) Lcommandline_globals.o Lcommandline_misc.o Lcommandline_numbertheory.o Lcommandline_values_zeros.o
+-OBJ3=$(OBJ2) Lcommandline_elliptic.o Lcommandline_twist.o Lcommandline.o cmdline.o
++OBJ2 = $(OBJ_L) Lcommandline_globals.o Lcommandline_misc.o Lcommandline_numbertheory.o Lcommandline_values_zeros.o
++OBJ3 = $(OBJ2) Lcommandline_elliptic.o Lcommandline_twist.o Lcommandline.o cmdline.o
  OBJECTS = $(OBJ3)
  
  all:
@@ -100,8 +121,8 @@
 -#	make find_L
 -#	make test
 +#	$(MAKE) print_vars
-+	$(MAKE) libLfunction.so
-+	$(MAKE) lcalc
++	$(MAKE) libLfunction$(LIBEXT)
++	$(MAKE) lcalc$(EXEEXT)
 +	$(MAKE) examples
 +#	$(MAKE) find_L
 +#	$(MAKE) test
@@ -109,65 +130,92 @@
  print_vars:
  	@echo OS_NAME = $(OS_NAME)
  
- lcalc: $(OBJECTS)
+-lcalc: $(OBJECTS)
 -	$(CC) $(CCFLAGS) $(INCLUDEFILES) $(OBJECTS) $(LDFLAGS) -o lcalc $(GMP_FLAGS)
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) $(OBJECTS) $(LDFLAGS) -o lcalc $(GMP_FLAGS)
++lcalc$(EXEEXT): $(OBJECTS)
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) $(OBJECTS) $(LDFLAGS) -o lcalc$(EXEEXT) $(GMP_FLAGS)
  
  examples:
 -	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/example.cc libLfunction.so -o example_programs/example $(GMP_FLAGS)
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) example_programs/example.cc libLfunction.so -o example_programs/example $(GMP_FLAGS)
- 
- 
- proc:
--	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/proc.cc libLfunction.so -o example_programs/proc $(GMP_FLAGS)
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) example_programs/proc.cc libLfunction.so -o example_programs/proc $(GMP_FLAGS)
- 
- test:
--	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/test.cc libLfunction.so -o example_programs/test $(GMP_FLAGS)
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) example_programs/test.cc libLfunction.so -o example_programs/test $(GMP_FLAGS)
- 
- find_L:
--	$(CC) $(CCFLAGS) $(INCLUDEFILES) find_L_functions/find_L_functions.cc libLfunction.so -o find_L_functions/find_L $(GMP_FLAGS)
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) find_L_functions/find_L_functions.cc libLfunction.so -o find_L_functions/find_L $(GMP_FLAGS)
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) example_programs/example.cc libLfunction$(LIBEXT) -o example_programs/example$(EXEEXT) $(GMP_FLAGS)
 +
+ 
++proc$(EXEEXT):
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) example_programs/proc.cc libLfunction$(LIBEXT) -o example_programs/proc$(EXEEXT) $(GMP_FLAGS)
+ 
+-proc:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/proc.cc libLfunction.so -o example_programs/proc $(GMP_FLAGS)
++test$(EXEEXT):
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) example_programs/test.cc libLfunction$(LIBEXT) -o example_programs/test$(EXEEXT) $(GMP_FLAGS)
+ 
+-test:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/test.cc libLfunction.so -o example_programs/test $(GMP_FLAGS)
++find_L$(EXEEXT):
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) find_L_functions/find_L_functions.cc libLfunction$(LIBEXT) -o find_L_functions/find_L$(EXEEXT) $(GMP_FLAGS)
+ 
+-find_L:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) find_L_functions/find_L_functions.cc libLfunction.so -o find_L_functions/find_L $(GMP_FLAGS)
  
  .cc.o:
 -	$(CC) $(CCFLAGS) $(INCLUDEFILES) -c $<
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -c $<
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) -c $<
 +
-+# Warning: We (Sage) add $CXXFLAGS to CCFLAGS above.
++# Warning: We (Sage) add $CXXFLAGS to CXXFLAGS above.
  .c.o:
- 	$(CC) $(CCFLAGS) $(INCLUDEFILES) -c $<
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) -c $<
++	$(CC) $(CXXFLAGS) $(INCLUDEFILES) -c $<
  
-@@ -227,7 +222,7 @@
+ 
+ Lglobals.o: ../include/Lglobals.h ../include/Lcommon.h ../include/Lcomplex.h ../include/Lnumeric.h ../include/Lint_complex.h
+@@ -227,7 +238,7 @@
  Lcommandline_elliptic.o: ../include/Lvalue.h ../include/Lfind_zeros.h
  Lcommandline_elliptic.o: ../include/Lcommandline_numbertheory.h
  Lcommandline_elliptic.o: ../include/Lcommandline_globals.h
 -	$(CC) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_elliptic.cc
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_elliptic.cc
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_elliptic.cc
  
  Lcommandline_twist.o: ../include/Lcommandline_twist.h ../include/L.h
  Lcommandline_twist.o: ../include/Lglobals.h ../include/Lcommon.h ../include/Lcomplex.h ../include/Lnumeric.h ../include/Lint_complex.h
-@@ -239,7 +234,7 @@
+@@ -239,10 +250,10 @@
  Lcommandline_twist.o: ../include/Lcommandline_numbertheory.h
  Lcommandline_twist.o: ../include/Lcommandline_globals.h
  Lcommandline_twist.o: ../include/Lcommandline_elliptic.h
 -	$(CC) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_twist.cc
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_twist.cc
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_twist.cc
  
  cmdline.o: ../include/cmdline.h ../include/getopt.h
- #$(CC) $(CCFLAGS) $(INCLUDEFILES) -DHAVE_LONG_LONG -c cmdline.c
-@@ -258,11 +253,11 @@
+-#$(CC) $(CCFLAGS) $(INCLUDEFILES) -DHAVE_LONG_LONG -c cmdline.c
++#$(CC) $(CXXFLAGS) $(INCLUDEFILES) -DHAVE_LONG_LONG -c cmdline.c
+ 
+ 
+ Lcommandline.o: ../include/Lcommandline.h ../include/L.h
+@@ -258,21 +269,21 @@
  Lcommandline.o: ../include/Lcommandline_elliptic.h
  Lcommandline.o: ../include/Lcommandline_twist.h
  Lcommandline.o: ../include/Lcommandline_values_zeros.h
 -	$(CC) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline.cc
-+	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline.cc
++	$(CXX) $(CXXFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline.cc
  
  
- libLfunction.so: $(OBJ_L)
+-libLfunction.so: $(OBJ_L)
 -	g++ -$(DYN_OPTION)  -o libLfunction.so $(OBJ_L)
-+	$(CXX) -$(DYN_OPTION) $(CXXFLAG64) -o libLfunction.so $(OBJ_L)
++libLfunction$(LIBEXT): $(OBJ_L)
++	$(CXX) -$(DYN_OPTION) $(CXXFLAG64) -o libLfunction$(LIBEXT) $(OBJ_L)
  
  clean:
- 	rm -f *.o lcalc libLfunction.so example_programs/example
+-	rm -f *.o lcalc libLfunction.so example_programs/example
++	rm -f *.o lcalc libLfunction$(LIBEXT) example_programs/example
+ 
+ install:
+-	cp -f lcalc $(INSTALL_DIR)/bin/.
+-	cp -f libLfunction.so $(INSTALL_DIR)/lib/.
+-	cp -rf ../include $(INSTALL_DIR)/include/Lfunction
++	cp -f lcalc$(EXEEXT) $(INSTALL_DIR)/bin/.
++	cp -f libLfunction$(LIBEXT) $(INSTALL_DIR)/lib/.
++	cp -rf ../include $(INSTALL_DIR)/include/libLfunction
+ 
+ 
+ SRCS = Lcommandline.cc Lcommandline_elliptic.cc Lcommandline_globals.cc Lcommandline_misc.cc Lcommandline_numbertheory.cc Lcommandline_twist.cc Lcommandline_values_zeros.cc Lgamma.cc Lglobals.cc Lmisc.cc Lriemannsiegel.cc Lriemannsiegel_blfi.cc cmdline.c
+ depend:
+-	makedepend -f depends -- $(CCFLAGS) -Y../include -- $(SRCS)
++	makedepend -f depends -- $(CXXFLAGS) -Y../include -- $(SRCS)

--- a/build/pkgs/lcalc/spkg-install
+++ b/build/pkgs/lcalc/spkg-install
@@ -6,22 +6,8 @@ if [ -z "$SAGE_LOCAL" ]; then
     exit 1
 fi
 
-# Add a sensible default optimisation flag. Change if necessary.
-OPTIMIZATION_FLAGS="-O3"
-
-# Most packages do not need all these set, but it is better to do them all
-# each time, rather than omit a flag by mistake:
-
-CFLAGS="$OPTIMIZATION_FLAGS $CFLAGS"
-CXXFLAGS="$OPTIMIZATION_FLAGS $CXXFLAGS"
-FCFLAGS="$OPTIMIZATION_FLAGS $FCFLAGS"
-F77FLAGS="$OPTIMIZATION_FLAGS $F77FLAGS"
-CPPFLAGS="-I$SAGE_LOCAL/include $CPPFLAGS"
-LDFLAGS="-L$SAGE_LOCAL/lib $LDFLAGS"
-
-# Compile for 64-bit if SAGE64 is set to 'yes':
 if [ "x$SAGE64" = xyes ]; then
-    echo >&2 "Building a 64-bit version of lcalc"
+    echo "Building a 64-bit version of lcalc"
 
     # Both Sun and GNU compilers use -m64 to build 64-bit code, but compilers
     # from IBM (on AIX), and HP (on HP-UX) do not. So allow the environment
@@ -34,141 +20,28 @@ if [ "x$SAGE64" = xyes ]; then
     if [ -z "$CXXFLAG64" ]; then
         CXXFLAG64="$CFLAG64" # default to that of the C compiler
     fi
-    export CFLAG64
-    export CXXFLAG64
 
     CFLAGS="$CFLAGS $CFLAG64"
     CXXFLAGS="$CXXFLAGS $CXXFLAG64"
-    FCFLAGS="$FCFLAGS $CXXFLAG64" # XXX Does this make sense?
-    F77FLAGS="$F77FLAGS $CXXFLAG64"
-    # Some packages may need LDFLAGS and/or ABI set here.
-    # LDFLAGS="$LDFLAGS $CFLAG64" # XXX Perhaps should use some LDFLAG64.
-    # ABI=64
-    # Normally one would just add this to CXXFLAGS, but since the Makefile
-    # does not import CXXFLAGS properly, and it would take a major change to
-    # sort out the Makefile properly, the variable can just be added here,
-    # and ${CXXFLAG64} added at the right point in the Makefile for 64-bit
-    # builds.
-    # (The last sentence apparently refers to CXXFLAG64 only. -leif)
 fi
 
 # If SAGE_DEBUG is set to 'yes', add debugging information.  Since both
 # the Sun and GNU compilers accept -g to give debugging information,
 # there is no need to do anything specific to one compiler or the other.
-
 if [ "x$SAGE_DEBUG" = xyes ]; then
-    echo >&2 "Code will be built with debugging information present. Unset 'SAGE_DEBUG'"
-    echo >&2 "or set it to 'no' if you don't want that."
+    echo "Code will be built with debugging information present. Unset 'SAGE_DEBUG'"
+    echo "or set it to 'no' if you don't want that."
 
-    CFLAGS="$CFLAGS -g"
-    CXXFLAGS="$CXXFLAGS -g"
-    FCFLAGS="$FCFLAGS -g"
-    F77FLAGS="$F77FLAGS -g"
+    CFLAGS="$CFLAGS -O0 -g"
+    CXXFLAGS="$CXXFLAGS -O0 -g"
 else
-    echo >&2 "No debugging information will be used during the build of this package."
-    echo >&2 "Set 'SAGE_DEBUG' to 'yes' if you want debugging information present (-g added)."
+    echo "No debugging information will be used during the build of this package."
+    echo "Set 'SAGE_DEBUG' to 'yes' if you want debugging information present (-g added)."
 fi
-
-# Add appropriate flag(s) to show all warnings.
-# This test of a compiler is not perfect by any means, but is better than
-# nothing:
-
-if $CC -flags >/dev/null 2>&1; then
-    SUN_COMPILER=1
-    # The Sun compilers are fussy, and adding extra
-    # warnings will just show too many.
-else
-    # Assume gcc if not the Sun C compiler.
-    GNU_COMPILER=1
-    # Add -Wall to show all warnings.
-    CFLAGS="-Wall $CFLAGS"
-    CXXFLAGS="-Wall $CXXFLAGS"
-    FCFLAGS="-Wall $FCFLAGS"
-    F77FLAGS="-Wall $F77FLAGS"
-fi
-
-# Determine if the C++ compiler is the Sun or GNU compiler,
-# just to check we are not mixing GNU and non-GNU:
-if $CXX -flags >/dev/null 2>&1; then
-    SUN_COMPILER=1
-else
-    # Assume gcc/g++ if not the Sun C++ compiler.
-    GNU_COMPILER=1
-fi
-
-# Determine if the Fortran compiler is the Sun or GNU compiler:
-if [ -z "$SAGE_FORTRAN" ]; then
-    echo >&2 "No Fortran compiler has been defined. This is not normally a problem."
-else
-    if $SAGE_FORTRAN -flags >/dev/null 2>&1; then
-        SUN_COMPILER=1
-    else
-        GNU_COMPILER=1
-    fi
-fi
-
-# Check if SAGE_FORTRAN_LIB is defined, that the file actually exists.
-# SAGE_FORTRAN_LIB does not always need to be defined, but if it is defined,
-# then the file should exist.
-if [ -n "$SAGE_FORTRAN_LIB" ] && [ ! -r "$SAGE_FORTRAN_LIB" ]; then
-    echo >&2 "Error: SAGE_FORTRAN_LIB is defined as '$SAGE_FORTRAN_LIB',"
-    echo >&2 "but that file does not exist (or isn't readable)."
-    exit 1
-fi
-
-# Checks that the user is not mixing the Sun and GNU compilers. This problem
-# has been seen on code built with the aid of SCons, but in general could
-# happen with any code if the user has specified a C compiler but not a C++ one.
-# This problem is even more likely to occur with the Fortran compiler - I've
-# done it myself when building Sage!
-if [ "x$SUN_COMPILER" = "x1" ] && [ "x$GNU_COMPILER" = "x1" ]; then
-    echo >&2 "Error: You are mixing the Sun and GNU C/C++/Fortran compilers."
-    echo >&2 "Such a combination will lead to problems."
-    echo >&2 "Check the environment variables CC, CXX & SAGE_FORTRAN carefully."
-    echo >&2 "Exiting ..."
-    exit 1
-fi
-
-echo "The following environment variables will be exported:"
-
-# These are all used by GNU to specify compilers:
-echo "Using CC=$CC"
-echo "Using CXX=$CXX"
-echo "Using FC=$FC"
-echo "Using F77=$F77"
-
-# Usually, one would add LD here, too.
-echo "Using MAKE=$MAKE"
-
-# Used by Sage in connection with Fortran:
-echo "Using SAGE_FORTRAN=$SAGE_FORTRAN"
-echo "Using SAGE_FORTRAN_LIB=$SAGE_FORTRAN_LIB"
-
-# Flags which may be set:
-echo "Using CFLAG64=$CFLAG64"
-echo "Using CXXFLAG64=$CXXFLAG64"
-echo "Using CFLAGS=$CFLAGS"
-echo "Using CXXFLAGS=$CXXFLAGS"
-echo "Using FCFLAGS=$FCFLAGS"
-echo "Using F77FLAGS=$F77FLAGS"
-echo "Using CPPFLAGS=$CPPFLAGS"
-echo "Using LDFLAGS=$LDFLAGS"
-echo "Using ABI=$ABI"
-echo "'configure' scripts and/or makefiles might override these later."
-echo " "
 
 # Export everything. Probably not necessary in most cases.
 export CFLAGS
 export CXXFLAGS
-export FCFLAGS
-export F77FLAGS
-export CPPFLAGS
-export LDFLAGS
-export ABI
-# (Variables like CC, CXX etc. have already been exported by 'sage-env'.)
-
-# End of pretty general spkg-install file.
-# Now do the specific things needed for this package (lcalc).
 
 success() {
     if [ $? -ne 0 ]; then
@@ -179,12 +52,15 @@ success() {
 
 export DEFINES=""
 
+# Set installation directory
+export INSTALL_DIR="$SAGE_LOCAL/"
+
 cd src
 
 # Apply Sage-specific patches: (See SPKG.txt for details on the patches.)
-echo >&2 "Patching the upstream source code for Sage..."
+echo "Patching the upstream source code for Sage..."
 for patch in ../patches/*.patch; do
-    patch -p1 <"$patch"
+    patch -p1 < "$patch"
     success "patch $patch failed to apply"
 done
 
@@ -194,34 +70,12 @@ done
 cd src   # Now we are in src/src.
 
 # Build everything:
-echo >&2 "Now building lcalc, example programs and the shared library..."
+echo "Now building lcalc, example programs and the shared library..."
 $MAKE
-success 'make'
+success "$MAKE"
 
-echo >&2 "Now copying over lcalc binary..."
-cp lcalc "$SAGE_LOCAL"/bin
-success 'copying binary'
-
-echo >&2 "Now copying over lcalc library..."
-
-# Remove next few lines when MacOS X 10.4 (Darwin 8) is no longer supported.
-# 10.4 does not seem to compile with .so extension in the library files.
-if [ "$UNAME" = "Darwin" ]; then
-    if [ `sysctl -n kern.osrelease | cut -d . -f 1` -lt 9 ]; then
-        cp libLfunction.so "$SAGE_LOCAL"/lib/libLfunction.dylib
-        success "copying libLfunction.dylib"
-    fi
-fi # End of MacOS X 10.4 specific instructions
-
-if [ "$UNAME" = "CYGWIN" ]; then
-    cp libLfunction.so "$SAGE_LOCAL"/lib/libLfunction.dll
-else
-    cp libLfunction.so "$SAGE_LOCAL"/lib/
-fi
-success "copying libLfunction.so"
-
-echo >&2 "Now copying over lcalc library header files..."
-rm -fr "$SAGE_LOCAL"/include/lcalc
-mkdir -p "$SAGE_LOCAL"/include/lcalc
-cp ../include/* "$SAGE_LOCAL"/include/lcalc
-success 'copying header files'
+# Install everything
+echo "Now installing lcalc binary, library and header files..."
+rm -fr "$SAGE_LOCAL"/include/libLfunction
+$MAKE install
+success "$MAKE install"


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13351">trac #13351</a>.

Spkg diff, for review only.

Reported by: jpflori

Component: cygwin

CC: kcrisman,, dimpase

Report Upstream: N/A

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.9.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13351/trac_13351.patch">trac_13351.patch: </a> by jpflori at 20120808T21:45:01</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13351/lcalc.diff">lcalc.diff: Spkg diff, for review only.</a> by jpflori at 20120808T21:46:27</li></ol>
