### PR TITLE
The libpng12 spkg should also create symbolic links from `libpng.*` for its libraries

### DIFF
--- a/build/pkgs/libpng/SPKG.txt
+++ b/build/pkgs/libpng/SPKG.txt
@@ -2,7 +2,12 @@
 
 == Description ==
 
-libpng is the official PNG reference library. It supports almost all PNG features, is extensible, and has been extensively tested for over 13 years. The home site for development versions (i.e., may be buggy or subject to change or include experimental features) is http://libpng.sourceforge.net/, and the place to go for questions about the library is the png-mng-implement mailing list.
+libpng is the official PNG reference library. It supports almost all PNG
+features, is extensible, and has been extensively tested for over 13 years.
+The home site for development versions (i.e., may be buggy or subject to
+change or include experimental features) is http://libpng.sourceforge.net/,
+and the place to go for questions about the library is the png-mng-implement
+mailing list.
 
 Website: http://www.libpng.org/pub/png/libpng.html
 
@@ -20,21 +25,44 @@ The png mailing lists - see http://www.libpng.org/pub/png/pngmisc.html#lists
 
 == Dependencies ==
 
-This spkg requires
+This spkg depends on:
 
  * libz
 
-This spkg provides dependencies for
-
- * the Sage library
- * tachyon
- * matplotlib
-
 == Special Update/Build Instructions ==
 
- * No changes went into src. There are two different tarballs, but we use the one with configure.
+ * No changes went into src. There are two different tarballs, but we use the
+   one with configure.
+ * On Darwin, the symbolic links libpng.* created by libpng12 may interfere
+   with a system-wide libPng.dylib.
+   This system-wide library is likely to be a different version and on top of
+   that the symbols exported there are prefixed with "_cg" (for "Core Graphics"),
+   so even if by chance the functionalities of the two libraries were interchangeable,
+   libraries or applications looking for one and being presented the other won't
+   find the symbols they expect.
+   Note the uppercase "P" which could prevent this conflict; unfortunately, the
+   default filesystem used by Apple is case-insensitive.
+   Also note there would be no problem if the system-wide library was not looked
+   for when Sage is being built or run, but that's not the case either;
+   it is at least looked for by the "ImageIO" framework:
+   - when Python is built with Mac OS extensions, fixed in #4008;
+   - when Mercurial is built because it uses $EDITOR, cf. #4678;
+   - when R is built and it finds -lpng, cf. #4409 and #11696.
+   As not all of these problems are easily dealt with and new ones may arise,
+   we chose to delete the $SAGE_LOCAL/lib/libpng.* symlinks on Darwin.
+   Therefore, some package as matplotlib (cf. #11686) which by default looks for
+   -lpng are patched to look for -lpng12 (unless pkg-config is installed; in
+   this case indeed we can use a non-conflicting libpng.pc symlinking to
+   libpng12.pc).
 
 == Changelog ==
+
+=== libpng-1.2.35.p5 (Leif Leonhardy, Jean-Pierre Flori, 19 February 2013) ===
+ * #11696: Correctly build and install libpng.
+ * Delete symlinks from libpng.* in $SAGE_LOCAL/lib on Darwin only.
+ * Fix order of additions of flags and do not drop user settings.
+ * Use $MAKE and quote $UNAME.
+ * Use SYMBOL_PREFIX trick on Cygwin to build a correct import library.
 
 === libpng-1.2.35.p4 (Simon King, 10th December 2011) ===
  * #12131: Use --libdir, to make the package work on openSUSE.
@@ -58,7 +86,8 @@ This spkg provides dependencies for
 
 === libpng-1.2.34 (Michael Abshoff, February 15th, 2009) ===
  * update to latest upstream release (security related)
- * delete SAGE_LOCAL/lib/libpng.* to avoid OSX specific issues. This required a set of other fixes.
+ * delete SAGE_LOCAL/lib/libpng.* to avoid OSX specific issues. This required
+   a set of other fixes.
  * unset RM
  * check if SAGE_LOCAL is set
 

--- a/build/pkgs/libpng/spkg-install
+++ b/build/pkgs/libpng/spkg-install
@@ -1,57 +1,75 @@
 #!/usr/bin/env bash
 
-if [ "$SAGE_LOCAL" = "" ]; then
-   echo "SAGE_LOCAL undefined ... exiting";
-   echo "Maybe run 'sage -sh'?"
-   exit 1
+if [ -z "$SAGE_LOCAL" ]; then
+    echo >&2 "Error: SAGE_LOCAL undefined - exiting..."
+    echo >&2 "Maybe run 'sage -sh'?"
+    exit 1
 fi
 
-unset RM
-
-cd src
-
-# Need to detect zlib
-if [ "x$SAGE64" = xyes ]; then
-    CFLAGS="-m64 $CFLAGS -fPIC -g"
-    LDFLAGS="-m64"; export LDFLAGS
+if [ "$SAGE64" = yes ]; then
+    CFLAGS="$CFLAGS -m64 -fPIC -g"
+    LDFLAGS="$LDFLAGS -m64"
 else
     CFLAGS="$CFLAGS -fPIC -g"
 fi
-export CFLAGS
 
-CPPFLAGS="$CPPFLAGS -I$SAGE_LOCAL/include"
-export CPPFLAGS
+# Pick up Sage's zlib:
+export CPPFLAGS="-I$SAGE_LOCAL/include $CPPFLAGS"
+export LDFLAGS="-L$SAGE_LOCAL/lib $LDFLAGS"
+
+cd src
 
 ./configure --prefix="$SAGE_LOCAL" --libdir="$SAGE_LOCAL/lib" --enable-shared=yes
 if [ $? -ne 0 ]; then
-    echo "Error configuring libpng"
+    echo >&2 "Error configuring libpng"
     exit 1
 fi
 
-make
+# Needed to generate a correct import library
+if [ "$UNAME" = "CYGWIN" ]; then
+    MAKE="$MAKE SYMBOL_PREFIX= "
+fi
 
+echo "Building libpng..."
+$MAKE
 if [ $? -ne 0 ]; then
-    echo "Error building libpng"
+    echo >&2 "Error building libpng."
     exit 1
 fi
 
-make install
-
+echo "Installing libpng..."
+$MAKE install
 if [ $? -ne 0 ]; then
-    echo "Error installing libpng"
+    echo >&2 "Error installing libpng."
     exit 1
 fi
 
-if [ $UNAME = "CYGWIN" ]; then
-  rm -rf "$SAGE_LOCAL"/lib/libpng12.dll.a
-  rm -rf "$SAGE_LOCAL"/lib/libpng12.la
-  cp "$SAGE_LOCAL"/bin/cygpng12-0.dll "$SAGE_LOCAL"/lib/libpng12.dll
-
-  if [ $? -ne 0 ]; then
-      echo "Error installing libpng"
-      exit 1
-  fi
+# On Darwin, the symbolic links libpng.* created by libpng12 may interfere
+# with a system-wide libPng.dylib.
+# This system-wide library is likely to be a different version and on top of
+# that the symbols exported there are prefixed with "_cg" (for "Core Graphics"),
+# so even if by chance the functionalities of the two libraries were interchangeable,
+# libraries or applications looking for one and being presented the other won't
+# find the symbols they expect.
+# Note the uppercase "P" which could prevent this conflict; unfortunately, the
+# default filesystem used by Apple is case-insensitive.
+# Also note there would be no problem if the system-wide library was not looked
+# for when Sage is being built or run, but that's not the case either;
+# it is at least looked for by the "ImageIO" framework:
+# - when Python is built with Mac OS extensions, fixed in #4008;
+# - when Mercurial is built because it uses $EDITOR, cf. #4678;
+# - when R is built and it finds -lpng, cf. #4409 and #11696.
+# As not all of these problems are easily dealt with and new ones may arise,
+# we chose to delete the $SAGE_LOCAL/lib/libpng.* symlinks on Darwin.
+# Therefore, some package as matplotlib (cf. #11686) which by default looks for
+# -lpng are patched to look for -lpng12 (unless pkg-config is installed; in
+# this case indeed we can use a non-conflicting libpng.pc symlinking to
+# libpng12.pc).
+if [ "$UNAME" = "Darwin" ]; then
+    echo "Deleting libpng.*..."
+    rm -rf "$SAGE_LOCAL"/lib/libpng.*
+    if [ $? -ne 0 ]; then
+        echo >&2 "Error deleting symlinks."
+        exit 1
+    fi
 fi
-
-echo "Deleting libpng.*"
-rm -rf "$SAGE_LOCAL"/lib/libpng.*


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/11696">trac #11696</a>.

Spkg diff, for review only.

Reported by: leif

Component: packages

CC: jdemeyer,, jhpalmieri,, kcrisman,, dimpase

Report Upstream: N/A

Authors: Leif Leonhardy, Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.8.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/11696/libpng-1.2.35.p5.diff">libpng-1.2.35.p5.diff: Spkg diff, for review only.</a> by jpflori at 20130219T10:04:50</li></ol>
