### PR TITLE
Patch to FLINT fails to apply because of double path separator // in filenames

### DIFF
--- a/build/pkgs/flint/SPKG.txt
+++ b/build/pkgs/flint/SPKG.txt
@@ -37,6 +37,9 @@ GPL V2+
 
 == Changelog ==
 
+=== flint-1.5.2.p3 (Timo Kluck, 7 March 2013) ===
+  * #14241: Fix double // path separators in longlong.patch
+
 === flint-1.5.2.p2 (Paul-Olivier Dehaye, 16 October 2012) ===
   * #9697: Remove the file 'src/zn_poly/demo/bernoulli/.DS_Store'
 

--- a/build/pkgs/flint/patches/longlong.patch
+++ b/build/pkgs/flint/patches/longlong.patch
@@ -1,6 +1,6 @@
-diff -ur flint-1.5.2.orig//longlong.h flint-1.5.2//longlong.h
---- flint-1.5.2.orig//longlong.h	2009-09-23 12:03:27.000000000 +0200
-+++ flint-1.5.2//longlong.h	2010-11-25 07:00:41.000000000 +0100
+diff -ur flint-1.5.2.orig/longlong.h flint-1.5.2/longlong.h
+--- flint-1.5.2.orig/longlong.h	2009-09-23 12:03:27.000000000 +0200
++++ flint-1.5.2/longlong.h	2010-11-25 07:00:41.000000000 +0100
 @@ -411,46 +411,6 @@
    __asm__ ("adds\t%1, %4, %5\n\tadc\t%0, %2, %3"			\
  	   : "=r" (sh), "=&r" (sl)					\


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14241">trac #14241</a>.

Reported by: tkluck

Component: packages

CC: 

Report Upstream: N/A

Authors: Timo Kluck

Dependencies: 

Work issues: 

Reviewers: Leif Leonhardy

Merged in: sage-5.9.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14241/trac_14241_path_separator_flint.patch">trac_14241_path_separator_flint.patch: </a> by tkluck at 20130307T15:29:43</li></ol>
