### PR TITLE
"sage -i" should only run sage-location if it exists

### DIFF
--- a/src/bin/sage
+++ b/src/bin/sage
@@ -803,9 +803,13 @@ install() {
         fi
     done
 
-    # Run sage-location to update paths of the package(s) we just
-    # installed.
-    exec sage-location
+    # Run sage-location, if it exists, to update paths of the
+    # package(s) we just installed.
+    if [ -x "$SAGE_LOCAL/bin/python" -a -x "$SAGE_LOCAL/bin/sage-location" ]; then
+        exec sage-location
+    else
+        exit 0
+    fi
 }
 
 if [ "$1" = '-optional' -o "$1" = "--optional" ]; then


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14303">trac #14303</a>.

root repo

Reported by: jhpalmieri

Component: build

CC: jdemeyer

Report Upstream: N/A

Authors: John Palmieri

Dependencies: 

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14303/trac_14303-location.patch">trac_14303-location.patch: root repo</a> by jhpalmieri at 20130319T15:23:30</li></ol>
