### PR TITLE
termcap: symlink libtermcap.a to libncurses.a

### DIFF
--- a/build/pkgs/termcap/SPKG.txt
+++ b/build/pkgs/termcap/SPKG.txt
@@ -27,6 +27,10 @@ None
 
 == Changelog ==
 
+=== termcap-1.3.1.p3 (Jeroen Demeyer, 28 March 2012) ===
+ * Trac #12725: Symlink libtermcap.a to libncurses.a if we cannot link
+   programs against -lncurses.
+
 === termcap-1.3.1.p2 (Jeroen Demeyer, 11 January 2012) ===
  * Trac #12282: Add patches/strcmp_NULL.patch to fix a bug when the
    environment variable TERM is not set.

--- a/build/pkgs/termcap/spkg-install
+++ b/build/pkgs/termcap/spkg-install
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 
 if [ "$SAGE_LOCAL" = "" ]; then
-   echo "SAGE_LOCAL undefined ... exiting";
-   echo "Maybe run 'sage -sh'?"
-   exit 1
+    echo >&2 "SAGE_LOCAL undefined ... exiting"
+    echo >&2 "Maybe run 'sage --sh'?"
+    exit 1
 fi
 
 CFLAGS="-O2 -g -fPIC $CFLAGS"
 
 if [ "x$SAGE64" = xyes ]; then
-   CFLAGS="$CFLAGS -m64"
+    CFLAGS="$CFLAGS -m64"
 fi
 export CFLAGS
 
@@ -26,25 +26,35 @@ done
 
 build()
 {
-    if [ ! -f Makefile ]; then
-        ./configure --prefix="$SAGE_LOCAL"
-        if [ $? -ne 0 ]; then
-            echo "ERROR configuring termcap"
-            exit 1
-        fi
+    ./configure --prefix="$SAGE_LOCAL"
+    if [ $? -ne 0 ]; then
+        echo >&2 "Error configuring termcap"
+        exit 1
     fi
+
     $MAKE CFLAGS="$CFLAGS" install
     if [ $? -ne 0 ]; then
-        echo "ERROR building termcap"
+        echo >&2 "Error building termcap"
         exit 1
     fi
 }
 
 build
 
-if [ $? -eq 0 -a $SAGE_LOCAL/lib/libtermcap.a ]; then
-    echo "Success building termcap"
+# If we cannot link programs against -lncurses, then symlink
+# libtermcap.a to libncurses.a.  This is to support the PARI and
+# Python build scripts when /usr/lib/libncurses.so exists but
+# cannot be linked (e.g. because we are cross-compiling).
+# See #12725.
+if testcflags.sh -lncurses >/dev/null; then
+    echo "Good, we can link against libncurses on your system."
 else
-    echo "ERROR building termcap."
-    exit 1
+    echo "We cannot link against libncurses on your system,"
+    echo "making a symbolic link libncurses.a -> libtermcap.a"
+    echo "(to work around bugs in the PARI and Python build scripts)"
+    cd "$SAGE_LOCAL/lib" && ln -s libtermcap.a libncurses.a
+    if [ $? -ne 0 ]; then
+        echo >&2 "Error making symbolic link libncurses.a -> libtermcap.a"
+        exit 1
+    fi
 fi


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12725">trac #12725</a>.

Diff for the termcap spkg, for review only

Reported by: jdemeyer

Component: packages

CC: jpflori

Report Upstream: Reported upstream. No feedback yet.

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Volker Braun

Merged in: sage-5.7.beta3

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12725/termcap-1.3.1.p3.diff">termcap-1.3.1.p3.diff: Diff for the termcap spkg, for review only</a> by jdemeyer at 20120328T09:15:12</li></ol>
