### PR TITLE
Let lrcalc build as a shared library on Cygwin.

### DIFF
--- a/build/pkgs/lrcalc/SPKG.txt
+++ b/build/pkgs/lrcalc/SPKG.txt
@@ -2,7 +2,7 @@
 
 == Description ==
 
-lrcalc 1.1.6 beta2: Littlewood-Richardson Calculator
+lrcalc-sage-1.1.6: Littlewood-Richardson Calculator
 
 http://math.rutgers.edu/~asbuch/lrcalc/
 
@@ -25,10 +25,11 @@ Anders S. Buch (asbuch@math.rutgers.edu)
 
 == Changelog ==
 
-=== lrcalc-1.1.6 (Jean-Pierre Flori, 18 December 2012)  ===
+=== lrcalc-1.1.6 (Jean-Pierre Flori, December 2012 - February 2013)  ===
 
- * Updated to lrcalc-sage-1.1.6: let lrcalc build a shared library on Cygwin.
- * Stop tracking the src directory which is now tracked upstream.
+ * Trac #13839:
+  * Updated to lrcalc-sage-1.1.6: let lrcalc build a shared library on Cygwin.
+  * Stop tracking the src directory which is now tracked upstream.
 
 === lrcalc-1.1.6beta1 (Nicolas M. Thiéry, June 2012)  ===
 
@@ -39,7 +40,7 @@ Anders S. Buch (asbuch@math.rutgers.edu)
 
 === lrcalc-1.1.6beta.p0 (Nicolas M. Thiéry, June 2012)  ===
 
-Fixed make -> $MAKE
+ * Fixed make -> $MAKE
 
 === lrcalc-1.1.6beta (Nicolas M. Thiéry, January 2012)  ===
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13839">trac #13839</a>.

Spkg diff, for review only.

Reported by: jpflori

Component: cygwin

CC: kcrisman,, dimpase,, nthiery

Report Upstream: None of the above - read trac for reasoning.

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.8.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13839/lrcalc-1.1.6beta2.diff">lrcalc-1.1.6beta2.diff: Spkg diff, for review only.</a> by jpflori at 20121217T16:22:09</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13839/lrcalc-1.1.6beta2.2.diff">lrcalc-1.1.6beta2.2.diff: Spkg diff, for review only.</a> by jpflori at 20121218T15:22:06</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13839/lrcalc-1.1.6.diff">lrcalc-1.1.6.diff: Spkg diff, for review only.</a> by jpflori at 20130219T10:16:45</li></ol>
