### PR TITLE
Let Singular link to termcap on Cygwin

### DIFF
--- a/build/pkgs/singular/SPKG.txt
+++ b/build/pkgs/singular/SPKG.txt
@@ -56,6 +56,8 @@ Several patches are applied.
  * singular_part_of_changeset_baadc0f7.patch: Backport a small part
    of https://github.com/Singular/Sources/commit/9ece45a2420dc43ff03a48c40423a3009c235fdd
    that fixes one memory corruption (writing out of bound).
+ * cygwin-makefile.patch: simple fix for Cygwin, see
+   http://www.singular.uni-kl.de:8002/trac/ticket/476/
 
 Other notes
  * The option '--without-dynamic-kernel' is used on *all*
@@ -82,6 +84,10 @@ Other notes
    for easier debugging of memory corruptions.
 
 == ChangeLog ==
+
+=== singular-3-1-5.p4 (Jean-Pierre Flori, 12 February 2013) ===
+ * Trac #14033: prevent Singular from always linking to ncurses on
+   Cygwin.
 
 === singular-3-1-5.p3 (Volker Braun, 28 December 2012) ===
  * Trac #13876: Rename SINGULAR_XALLOC to SAGE_DEBUG

--- a/build/pkgs/singular/patches/cygwin-makefile.patch
+++ b/build/pkgs/singular/patches/cygwin-makefile.patch
@@ -1,0 +1,15 @@
+diff -druN src.orig/Singular/Makefile.in src/Singular/Makefile.in
+--- src.orig/Singular/Makefile.in	2012-07-11 12:00:13.000000000 +0200
++++ src/Singular/Makefile.in	2013-02-04 23:43:26.565194514 +0100
+@@ -121,9 +121,9 @@
+ else
+ ## for cones & fans if under Win OS:
+ ## put "-lgfan -lcddgmp " before "-Xlinker" in definition of LIBS and LIBSG
+-LIBS		= -lsingfac -lsingcf -lntl  -static -lreadline -lhtmlhelp -Xlinker -Bdynamic -lgmp -lomalloc_ndebug -lncurses
++LIBS		= @NEED_LIBS@
+ ## -lpython_module -lpython2.4 /usr/local/lib/libboost_python-gcc-d-1_32.dll
+-LIBSG		= -lsingfac -lsingcf -lntl  -static -lreadline -lhtmlhelp -Xlinker -Bdynamic -lgmp -lncurses
++LIBSG		= @NEED_LIBSG@
+ ## with cdd and gfan: LIBSG		= -lsingfac -lsingcf -lntl  -static -lreadline -lhtmlhelp -lgfan -lcddgmp -Xlinker -Bdynamic -lgmp -lncurses
+ endif
+ MP_LIBS		= @MP_LIBS@


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14033">trac #14033</a>.

Spkg diff, for review only.

Reported by: jpflori

Component: cygwin

CC: kcrisman,, dimpase

Report Upstream: Fixed upstream, but not in a stable release.

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.8.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14033/singular-3-1-5.p4.diff">singular-3-1-5.p4.diff: Spkg diff, for review only.</a> by jpflori at 20130213T12:52:08</li></ol>
