### PR TITLE
Let r-2.15.2 build on Cygwin

### DIFF
--- a/build/pkgs/r/SPKG.txt
+++ b/build/pkgs/r/SPKG.txt
@@ -36,15 +36,20 @@ much code written for S runs unaltered under R.
      The corresponding patch to m4/clibs.m4 is not included, as
      autoconf-2.68 gives errors, even on the clean upstream sources.
    - R.sh.in: Set R_HOME_DIR to "${SAGE_LOCAL}/lib/R/" when running R.
+   - cygwin-logl.patch: disable use of logl on Cygwin, see #14078.
 
 == Changelog ==
+
+=== r-2.15.2.p1 (Jean-Pierre Flori, 7 February 2013) ===
+ * #14078: do not use logl on Cygwin.
+
 === r-2.15.2.p0 (Emmanuel Charpentier, 25 January 2013) ===
-  * "monkey see-monkey do" upgrade to current upstream
-  * simple drop of curent source in src
-  * removed patches/install_parallel.patch : patch complained
-    about a "reversed (or previously applied) patch detected!".
-  * re-enables installation of upstream source packages
-    (ticket #14008).
+ * "monkey see-monkey do" upgrade to current upstream
+ * simple drop of curent source in src
+ * removed patches/install_parallel.patch : patch complained
+   about a "reversed (or previously applied) patch detected!".
+ * re-enables installation of upstream source packages
+   (ticket #14008).
 
 === r-2.14.0.p6 (Jeroen Demeyer, 10 September 2012) ===
  * #13443: some clean up of spkg-install.

--- a/build/pkgs/r/patches/cygwin-logl.patch
+++ b/build/pkgs/r/patches/cygwin-logl.patch
@@ -1,0 +1,14 @@
+diff -dru src.orig/src/nmath/nmath.h src/src/nmath/nmath.h
+--- src.orig/src/nmath/nmath.h	2012-04-16 00:05:35.000000000 +0200
++++ src/src/nmath/nmath.h	2013-02-07 10:48:06.473614931 +0100
+@@ -21,6 +21,10 @@
+ #ifndef MATHLIB_PRIVATE_H
+ #define MATHLIB_PRIVATE_H
+ 
++#ifdef __CYGWIN__
++#define logl log
++#endif /* __CYGWIN__ */
++
+ #ifdef HAVE_CONFIG_H
+ #  include <config.h>
+ #endif


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14078">trac #14078</a>.

Spkg diff, for review only.

Reported by: jpflori

Component: cygwin

CC: dimpase,, kcrisman

Report Upstream: N/A

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.7.beta4

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14078/r-2.15.2.p1.diff">r-2.15.2.p1.diff: Spkg diff, for review only.</a> by jpflori at 20130207T09:57:59</li></ol>
