### PR TITLE
PARI polred() bug

### DIFF
--- a/build/pkgs/pari/SPKG.txt
+++ b/build/pkgs/pari/SPKG.txt
@@ -69,6 +69,10 @@ of doubt, have a look at the file spkg-src.
 
 == Changelog ==
 
+=== pari-2.5.3.p3 (Jeroen Demeyer, 31 January 2013) ===
+ * Trac #13054: polred.patch: fix polred() bug.
+ * Trac #6743: remove Cygwin-specific hacks from spkg-install.
+
 === pari-2.5.3.p2 (Jeroen Demeyer, 7 January 2013) ===
  * Trac #13921: KERNELCFLAGS.patch: when SAGE_DEBUG=yes, compile mp.c
    with -O1 (and without -funroll-loops) to avoid a segmentation fault

--- a/build/pkgs/pari/patches/README.txt
+++ b/build/pkgs/pari/patches/README.txt
@@ -52,3 +52,8 @@ C files:
   - 28ea998bc661f5bbde18b6d6b0f50111a10ae16c
   - 249432f7088bfa114ed5cd3a5d64ef51ee968e35
 * galoisanalysis_p4.patch: fix segmentation fault under Electric Fence.
+* polred.patch: Fix polred(), add polredbest() based on upstream commits
+  - 2d00a24fbb1ffe8eba35b9a04763e36eef8a5f7b
+  - a3596c56f9439144a0dbed4c47bd6ff9485e3fc8
+  - 1a00ca416de4daebccaab2be1a4b8a061a9f2fde
+  - ad550d9bbfee8113087407c3262bffc27a020c98

--- a/build/pkgs/pari/patches/polred.patch
+++ b/build/pkgs/pari/patches/polred.patch
@@ -1,0 +1,752 @@
+diff -ruN src/src/basemath/base1.c b/src/basemath/base1.c
+--- src/src/basemath/base1.c	2012-10-05 10:18:20.000000000 +0200
++++ b/src/basemath/base1.c	2013-01-31 14:49:05.537512504 +0100
+@@ -1675,40 +1675,42 @@
+ ZX_is_better(GEN y, GEN x, GEN *dx)
+ {
+   GEN d = ZX_disc(y);
+-  long cmp = absi_cmp(d, *dx);
++  int cmp;
++  if (!*dx) *dx = ZX_disc(x);
++  cmp = absi_cmp(d, *dx);
+   if (cmp < 0) { *dx = d; return 1; }
+   if (cmp == 0) return cmp_abs_ZX(y, x) < 0;
+   return 0;
+ }
+ 
+-static GEN polred_aux(nfbasic_t *T, GEN *pro, long flag);
++static void polredbest_aux(nfbasic_t *T, GEN *pro, GEN *px, GEN *pdx, GEN *pa);
+ /* Seek a simpler, polynomial pol defining the same number field as
+  * x (assumed to be monic at this point) */
+ static GEN
+ nfpolred(nfbasic_t *T, GEN *pro)
+ {
+-  GEN x = T->x, dx = T->dx, a, z, rev, pow, dpow;
++  GEN x = T->x, dx, b, rev, pow, dpow;
+   long i, n = degpol(x), v = varn(x);
+ 
+   if (n == 1) {
+     T->x = deg1pol_shallow(gen_1, gen_m1, v);
+     *pro = NULL; return pol_1(v);
+   }
+-  z = polred_aux(T, pro, nf_ORIG | nf_RED);
+-  if (typ(z) != t_VEC || !ZX_is_better(gel(z,1),x,&dx))
+-    return NULL; /* no improvement */
+-
+-  rev = QXQ_reverse(gel(z,2), x);
+-  x = gel(z,1); if (DEBUGLEVEL>1) err_printf("xbest = %Ps\n",x);
++  polredbest_aux(T, pro, &x, &dx, &b);
++  if (x == T->x) return NULL; /* no improvement */
++  if (DEBUGLEVEL>1) err_printf("xbest = %Ps\n",x);
+ 
+   /* update T */
++  rev = QXQ_reverse(b, T->x);
+   pow = QXQ_powers(rev, n-1, x);
+   pow = Q_remove_denom(pow, &dpow);
+-  a = T->bas;
+-  for (i=2; i<=n; i++) gel(a,i) = QX_ZXQV_eval(gel(a,i), pow, dpow);
++  for (i=2; i<=n; i++) gel(T->bas,i) = QX_ZXQV_eval(gel(T->bas,i), pow, dpow);
+   (void)Z_issquareall(diviiexact(dx,T->dK), &(T->index));
+-  T->basden = get_bas_den(a);
+-  T->dx = dx; T->x = x; *pro = NULL; return rev;
++  T->basden = get_bas_den(T->bas);
++  T->dx = dx;
++  T->x = x;
++  *pro = NULL; /* reset */
++  return rev;
+ }
+ 
+ /* let bas a t_VEC of QX giving a Z-basis of O_K. Return the index of the
+@@ -1776,7 +1778,7 @@
+     x = Q_primpart(x);
+     RgX_check_ZX(x, "nfinit");
+     if (!ZX_is_irred(x)) pari_err(redpoler, "nfinit");
+-    if (flag & nf_RED || !gequal1(gel(x,lg(x)-1)))
++    if (flag & nf_RED || !equali1(gel(x,lg(x)-1)))
+       x = ZX_Q_normalize(x, &(T->lead));
+     nfmaxord(&S, x, flag, fa);
+     index = S.index;
+@@ -1822,26 +1824,32 @@
+ nfinitall(GEN x, long flag, long prec)
+ {
+   const pari_sp av = avma;
+-  GEN nf;
++  GEN nf, lead;
+   nfbasic_t T;
+ 
+   nfbasic_init(x, flag, NULL, &T);
+   nfbasic_add_disc(&T); /* more expensive after set_LLL_basis */
+-  if (T.lead != gen_1 && !(flag & nf_RED))
++  lead = T.lead;
++  if (lead != gen_1 && !(flag & nf_RED))
+   {
+     pari_warn(warner,"non-monic polynomial. Result of the form [nf,c]");
+     flag |= nf_RED | nf_ORIG;
+   }
+   if (flag & nf_RED)
+   {
+-    GEN ro, rev = nfpolred(&T, &ro);
++    GEN ro, rev;
++    /* lie to polred: more efficient to update *after* modreverse, than to
++     * unscale in the polred subsystem */
++    T.lead = gen_1;
++    rev = nfpolred(&T, &ro);
+     nf = nfbasic_to_nf(&T, ro, prec);
+     if (flag & nf_ORIG)
+     {
+       if (!rev) rev = pol_x(varn(T.x)); /* no improvement */
+-      if (T.lead != gen_1) rev = RgX_Rg_div(rev, T.lead);
++      if (lead != gen_1) rev = RgX_Rg_div(rev, lead);
+       nf = mkvec2(nf, mkpolmod(rev, T.x));
+     }
++    T.lead = lead; /* restore */
+   } else {
+     GEN ro; set_LLL_basis(&T, &ro, 0.99);
+     nf = nfbasic_to_nf(&T, ro, prec);
+@@ -1948,7 +1956,7 @@
+ get_polchar(CG_data *d, GEN x)
+ { return get_pol(d, RgM_RgC_mul(d->ZKembed,x)); }
+ 
+-/* return a defining polynomial for Q(w_i) */
++/* return a defining polynomial for Q(w_k) */
+ static GEN
+ get_polmin_w(CG_data *d, long k)
+ {
+@@ -1956,6 +1964,22 @@
+   if (g) (void)ZX_gcd_all(g, ZX_deriv(g), &g);
+   return g;
+ }
++/* return a defining polynomial for Q(w_k+w_l) */
++static GEN
++get_polmin_add2(CG_data *d, long k, long l)
++{
++  GEN g = get_pol(d, RgV_add(gel(d->ZKembed,k), gel(d->ZKembed,l)));
++  if (g) (void)ZX_gcd_all(g, ZX_deriv(g), &g);
++  return g;
++}
++/* return a defining polynomial for Q(w_k-w_l) */
++static GEN
++get_polmin_sub2(CG_data *d, long k, long l)
++{
++  GEN g = get_pol(d, RgV_sub(gel(d->ZKembed,k), gel(d->ZKembed,l)));
++  if (g) (void)ZX_gcd_all(g, ZX_deriv(g), &g);
++  return g;
++}
+ 
+ /* does x generate the correct field ? */
+ static GEN
+@@ -2044,13 +2068,67 @@
+   d->v = varn(T->x);
+   d->r1= T->r1; return prec;
+ }
++static void
++update(GEN *pai, GEN *pch, nfbasic_t *T, long orig)
++{
++  GEN ch = *pch, ai = *pai;
++  if (!ch)
++  { /* accuracy too low, compute algebraically */
++    ch = ZXQ_charpoly(ai, T->x, varn(T->x));
++    (void)ZX_gcd_all(ch, ZX_deriv(ch), &ch);
++  }
++  if (ZX_canon_neg(ch) && orig) ai = RgX_neg(ai);
++  if (DEBUGLEVEL>3) err_printf("polred: generator %Ps\n", ch);
++  if (T->lead != gen_1 && orig) ai = RgX_unscale(ai, ginv(T->lead));
++  *pch = ch; *pai = ai;
++}
++static GEN
++findmindisc(GEN y, GEN *pa)
++{
++  GEN a = *pa, x = gel(y,1), b = gel(a,1), dx = NULL;
++  long i, l = lg(y);
++  for (i = 2; i < l; i++)
++  {
++    GEN yi = gel(y,i);
++    if (ZX_is_better(yi,x,&dx)) { x = yi; b = gel(a,i); }
++  }
++  *pa = b; return x;
++}
++/* filter [y,b] from polred_aux: keep a single polynomial of degree n in y
++ * [ the best wrt discriminant ordering ], but keep all non-primitive
++ * polynomials */
++static void
++filter(GEN y, GEN b, long n)
++{
++  GEN x, a, dx;
++  long i, k = 1, l = lg(y);
++  a = x = dx = NULL;
++  for (i = 1; i < l; i++)
++  {
++    GEN yi = gel(y,i), ai = gel(b,i);
++    if (degpol(yi) == n)
++    {
++      if (dx && !ZX_is_better(yi,x,&dx)) continue;
++      if (!dx) dx = ZX_disc(yi);
++      x = yi; a = ai; continue;
++    }
++    gel(y,k) = yi;
++    gel(b,k) = ai; k++;
++  }
++  if (dx)
++  {
++    gel(y,k) = x;
++    gel(b,k) = a; k++;
++  }
++  setlg(y, k);
++  setlg(b, k);
++}
++
+ static GEN
+-polred_aux(nfbasic_t *T, GEN *pro, long flag)
++polred_aux(nfbasic_t *T, GEN *pro, long orig)
+ {
+   GEN b, y, x = T->x;
+-  long i, v = varn(x), l = lg(T->bas);
+-  const long orig = flag & nf_ORIG;
+-  const long nfred = flag & nf_RED;
++  long maxi, i, j, k, v = varn(x), n = lg(T->bas)-1;
+   nffp_t F;
+   CG_data d;
+ 
+@@ -2058,23 +2136,41 @@
+   *pro = F.ro;
+   d.ZKembed = F.M;
+ 
+-  y = cgetg(l, t_VEC);
+-  b = cgetg(l, t_COL);
++  /* n + 2 sum_{1 <= i <= n} n-i = n + n(n-1) = n*n */
++  y = cgetg(n*n + 1, t_VEC);
++  b = cgetg(n*n + 1, t_COL);
++  /* i = 1 */
+   gel(y,1) = deg1pol_shallow(gen_1, gen_m1, v);
+   gel(b,1) = gen_1;
+-  for (i = 2; i < l; i++)
++  for (i = k = 2; i <= n; i++)
+   {
+-    GEN ch, ai = gel(T->bas,i);
++    GEN ch, ai;
++    ai = gel(T->bas,i);
+     ch = get_polmin_w(&d, i);
+-    /* if accuracy too low, compute algebraically */
+-    if (!ch) ch = ZXQ_charpoly(ai, x, v);
+-    if (ZX_canon_neg(ch) && orig) ai = RgX_neg(ai);
+-    if (nfred && degpol(ch) == l-1) return mkvec2(ch, ai);
+-    if (DEBUGLEVEL>3) err_printf("polred: generator %Ps\n", ch);
+-    if (T->lead != gen_1 && orig) ai = RgX_unscale(ai, ginv(T->lead));
+-    gel(y,i) = ch;
+-    gel(b,i) = ai;
+-  }
++    update(&ai, &ch, T, orig);
++    gel(y,k) = ch;
++    gel(b,k) = ai; k++;
++  }
++  k = i;
++  maxi = minss(n, 3);
++  for (i = 1; i <= maxi; i++)
++    for (j = i+1; j <= n; j++)
++    {
++      GEN ch, ai;
++      ai = gadd(gel(T->bas,i), gel(T->bas,j));
++      ch = get_polmin_add2(&d, i, j);
++      update(&ai, &ch, T, orig);
++      gel(y,k) = ch;
++      gel(b,k) = ai; k++;
++
++      ai = gsub(gel(T->bas,i), gel(T->bas,j));
++      ch = get_polmin_sub2(&d, i, j);
++      update(&ai, &ch, T, orig);
++      gel(y,k) = ch;
++      gel(b,k) = ai; k++;
++    }
++  setlg(y, k);
++  setlg(b, k); filter(y, b, n);
+   if (!orig) return gen_sort_uniq(y, (void*)cmpii, &gen_cmp_RgX);
+   (void)sort_factor_pol(mkmat2(y, b), cmpii);
+   settyp(y, t_COL); return mkmat2(b, y);
+@@ -2085,10 +2181,58 @@
+ {
+   pari_sp av = avma;
+   GEN ro;
+-  nfbasic_t T; nfbasic_init(x, flag & (nf_PARTIALFACT|nf_RED), fa, &T);
++  nfbasic_t T; nfbasic_init(x, flag & nf_PARTIALFACT, fa, &T);
+   return gerepilecopy(av, polred_aux(&T, &ro, flag & nf_ORIG));
+ }
+ 
++/* finds "best" polynomial in polred_aux list, defaulting to T->x if none of
++ * them is primitive. *px is the ZX, characteristic polynomial of *pb, *pdx 
++ * its discriminant.
++ * Set *pro = polroots(T->x) [ NOT *px ], in case caller needs it. */
++static void
++polredbest_aux(nfbasic_t *T, GEN *pro, GEN *px, GEN *pdx, GEN *pb)
++{
++  GEN a, v, y, x = T->x, b = pol_x(varn(x)); /* default values */
++  long i, l, n = degpol(x);
++  v = polred_aux(T, pro, nf_ORIG);
++  *pdx = T->dx;
++  y = gel(v,2);
++  a = gel(v,1); l = lg(a);
++  for (i=1; i<l; i++)
++  {
++    GEN yi = gel(y,i);
++    pari_sp av = avma;
++    if (degpol(yi) == n && ZX_is_better(yi,x,pdx)) { x = yi; b = gel(a,i); }
++    else avma = av;
++  }
++  *px = x;
++  *pb = b;
++}
++GEN
++polredbest(GEN x, long flag)
++{
++  pari_sp av = avma;
++  GEN dx, ro, b;
++  long fl;
++  nfbasic_t T;
++  switch(flag)
++  {
++    default: pari_err(talker, "invalid flag in polredbest()");
++    case 0: fl = nf_PARTIALFACT; break;
++    case 1: fl = nf_PARTIALFACT|nf_ORIG; break;
++  }
++  nfbasic_init(x, fl, NULL, &T);
++  polredbest_aux(&T, &ro, &x, &dx, &b);
++  if (flag)
++  {
++    if (x == T.x)
++      b = pol_x(varn(x)); /* no improvement */
++    else
++      b = QXQ_reverse(b, T.x);
++    x = mkvec2(x, mkpolmod(b,x));
++  }
++  return gerepilecopy(av, x);
++}
+ /* FIXME: backward compatibility */
+ GEN
+ polred0(GEN x, long flag, GEN fa)
+@@ -2269,22 +2413,6 @@
+   return bound;
+ }
+ 
+-static GEN
+-findmindisc(GEN y, GEN *pa)
+-{
+-  GEN a = *pa, x = gel(y,1), b = gel(a,1), dx;
+-  long i, l = lg(y);
+-
+-  if (l == 2) { *pa = b; return x; }
+-  dx = ZX_disc(x);
+-  for (i = 2; i < l; i++)
+-  {
+-    GEN yi = gel(y,i);
+-    if (ZX_is_better(yi,x,&dx)) { x = yi; b = gel(a,i); }
+-  }
+-  *pa = b; return x;
+-}
+-
+ /* z "small" minimal polynomial of Mod(a,x), deg z = deg x */
+ static GEN
+ store(GEN x, GEN z, GEN a, nfbasic_t *T, long flag, GEN u)
+@@ -2351,7 +2479,7 @@
+   GEN y, a, u;
+   nfbasic_t T;
+ 
+-  nfbasic_init(x, flag & (nf_PARTIALFACT|nf_RED), NULL, &T);
++  nfbasic_init(x, flag & nf_PARTIALFACT, NULL, &T);
+   x = T.x; vx = varn(x);
+ 
+   if (degpol(x) == 1)
+diff -ruN src/src/functions/number_fields/polredabs b/src/functions/number_fields/polredabs
+--- src/src/functions/number_fields/polredabs	2012-09-25 23:10:47.000000000 +0200
++++ b/src/functions/number_fields/polredabs	2013-01-31 14:49:05.547513332 +0100
+@@ -17,8 +17,8 @@
+  \misctitle{Warning} This routine uses an exponential-time algorithm to
+  enumerate all potential generators, and may be exceedingly slow when the
+  number field has many subfields, hence a lot of elements of small $T_2$-norm.
+- E.g. do not try it on the compositum of many quadratic fields; in that case,
+- use \tet{polred} instead.
++ The function \tet{polredbest} is in general much faster (it runs in
++ polynomial time), and tends to return polynomials with smaller discriminants.
+ 
+  The binary digits of $\fl$ mean
+ 
+@@ -38,6 +38,15 @@
+  (has at most one large prime factor not in the \kbd{addprimes} table), the
+  result is the same.
+ 
++ \bprog
++ ? T = x^16 - 136*x^14 + 6476*x^12 - 141912*x^10 + 1513334*x^8 - 7453176*x^6 + 13950764*x^4 - 5596840*x^2 + 46225
++ ? T1 = polredabs(T); T2 = polredbest(T);
++ ? [ norml2(polroots(T1)), norml2(polroots(T2)) ]
++ %3 = [88.0000000, 120.000000]
++ ? [ sizedigit(poldisc(T1)), sizedigit(poldisc(T2)) ]
++ %4 = [75, 67]
++ @eprog
++
+ Variant: Instead of the above hardcoded numerical flags, one should use an
+  or-ed combination of
+ 
+diff -ruN src/src/functions/number_fields/polredbest b/src/functions/number_fields/polredbest
+--- src/src/functions/number_fields/polredbest	1970-01-01 01:00:00.000000000 +0100
++++ b/src/functions/number_fields/polredbest	2013-01-31 14:49:05.547513332 +0100
+@@ -0,0 +1,21 @@
++Function: polredbest
++Section: number_fields
++C-Name: polredbest
++Prototype: GD0,L,
++Help: polredbest(T,{flag=0}): reduction of the polynomial T (gives minimal
++ polynomials only). If flag=1, gives also elements.
++Doc: finds a polynomial with reasonably
++ small coefficients defining the same number field as $T$.
++ All $T$ accepted by \tet{nfinit} are also allowed here (e.g. non-monic
++ polynomials, \kbd{nf}, \kbd{bnf}, \kbd{[T,Z\_K\_basis]}). Contrary to
++ \tet{polredabs}, this routine runs in polynomial time, but it offers no
++ guarantee as to the minimality of its result.
++
++ If $\fl = 1$: outputs a two-component row vector $[P,a]$,  where $P$ is the
++ default output and \kbd{Mod(a, P)} is a root of the original $T$.
++ \bprog
++ ? polredbest(x^4 + 8, 1)
++ %1 = [x^4 + 2, Mod(x^3, x^4 + 2)]
++ ? charpoly(%[2])
++ %2 = x^4 + 8
++ @eprog
+diff -ruN src/src/headers/paridecl.h b/src/headers/paridecl.h
+--- src/src/headers/paridecl.h	2012-09-25 23:10:47.000000000 +0200
++++ b/src/headers/paridecl.h	2013-01-31 14:49:05.557525771 +0100
+@@ -889,6 +889,7 @@
+ GEN     polredabs0(GEN x, long flag);
+ GEN     polredabs2(GEN x);
+ GEN     polredabsall(GEN x, long flun);
++GEN     polredbest(GEN x, long flag);
+ GEN     smallpolred(GEN x);
+ GEN     smallpolred2(GEN x);
+ GEN     tschirnhaus(GEN x);
+diff -ruN src/src/test/32/compat b/src/test/32/compat
+--- src/src/test/32/compat	2012-09-25 23:10:47.000000000 +0200
++++ b/src/test/32/compat	2013-01-31 14:49:15.307512816 +0100
+@@ -787,13 +787,9 @@
+ ? factoreddiscf(p,fa)
+ 136866601
+ ? factoredpolred(p,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? factoredpolred2(p,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? factornf(x^3+x^2-2*x-1,t^3+t^2-2*t-1)
+ 
+ [x + mod(-t, t^3 + t^2 - 2*t - 1) 1]
+@@ -904,7 +900,7 @@
+ ? gcd(12345678,87654321)
+ 9
+ ? getheap()
+-[208, 45748]
++[208, 45584]
+ ? getrand()
+ Vecsmall([1220248512, -582244995, 485580680, -1643185972, -2103930341, -9694
+ 07356, 336208700, 1439513079, -1910826353, -2042699820, 222745475, 183991374
+@@ -2014,7 +2010,7 @@
+ ? orderell(tcurve,[1,2])
+ 6
+ ? ordred(x^3-12*x+45*x-1)
+-[x - 1, x^3 - 363*x - 2663, x^3 + 33*x - 1]
++[x - 1, x^3 + 33*x - 1]
+ ? padicprec(padicno,127)
+ 5
+ ? pascal(8)
+@@ -2093,15 +2089,16 @@
+ ? polint([0,2,3],[0,4,9],5)
+ 25
+ ? polred(x^5-2*x^4-4*x^3-96*x^2-352*x-568)
+-[x - 1, x^5 - x^4 - 6*x^3 + 6*x^2 + 13*x - 5, x^5 - x^4 + 2*x^3 - 4*x^2 + x 
+-- 1, x^5 - x^4 + 4*x^3 - 2*x^2 + x - 1, x^5 + 4*x^3 - 4*x^2 + 8*x - 8]
++[x - 1, x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1]
+ ? polred2(x^4-28*x^3-458*x^2+9156*x-25321)
+ 
+ [1 x - 1]
+ 
+-[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
++[1/115*x^2 - 14/115*x - 212/115 x^2 - 2*x - 9]
++
++[-1/115*x^2 + 14/115*x + 442/115 x^2 - 2*x - 9]
+ 
+-[2/897*x^3 - 14/299*x^2 - 1171/897*x + 9569/897 x^4 - 32*x^2 + 6]
++[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
+ 
+ [1/4485*x^3 - 7/1495*x^2 - 1034/4485*x + 7924/4485 x^4 - 8*x^2 + 6]
+ 
+@@ -2454,13 +2451,21 @@
+ ? smallinitell([0,0,0,-17,0])
+ [0, 0, 0, -17, 0, 0, -34, 0, -289, 816, 0, 314432, 1728]
+ ? smallpolred(x^4+576)
+-[x - 1, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
++[x - 1, x^2 - 3*x + 3, x^2 - 2*x + 2, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
+ ? smallpolred2(x^4+576)
+ 
+ [1 x - 1]
+ 
++[-1/192*x^3 - 1/8*x + 3/2 x^2 - 3*x + 3]
++
++[1/24*x^2 + 1 x^2 - 2*x + 2]
++
++[-1/24*x^2 + 1 x^2 - 2*x + 2]
++
+ [-1/192*x^3 - 1/8*x + 1/2 x^2 - x + 1]
+ 
++[1/192*x^3 + 1/8*x + 1/2 x^2 - x + 1]
++
+ [1/24*x^2 x^2 + 1]
+ 
+ [1/192*x^3 + 1/48*x^2 - 1/8*x x^4 - x^2 + 1]
+@@ -2650,6 +2655,6 @@
+ ? getstack()
+ 104
+ ? getheap()
+-[599, 110982]
++[599, 110954]
+ ? print("Total time spent: ",gettime);
+-Total time spent: 236
++Total time spent: 140
+diff -ruN src/src/test/32/nfields b/src/test/32/nfields
+--- src/src/test/32/nfields	2012-09-25 23:10:47.000000000 +0200
++++ b/src/test/32/nfields	2013-01-31 14:49:15.317513357 +0100
+@@ -926,45 +926,50 @@
+ ? polgalois(x^6-3*x^2-1)
+ [12, 1, 1, "A_4(6) = [2^2]3"]
+ ? polred(x^5-2*x^4-4*x^3-96*x^2-352*x-568)
+-[x - 1, x^5 - x^4 - 6*x^3 + 6*x^2 + 13*x - 5, x^5 - x^4 + 2*x^3 - 4*x^2 + x 
+-- 1, x^5 - x^4 + 4*x^3 - 2*x^2 + x - 1, x^5 + 4*x^3 - 4*x^2 + 8*x - 8]
++[x - 1, x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1]
+ ? polred(x^4-28*x^3-458*x^2+9156*x-25321,3)
+ 
+ [1 x - 1]
+ 
+-[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
++[1/115*x^2 - 14/115*x - 212/115 x^2 - 2*x - 9]
++
++[-1/115*x^2 + 14/115*x + 442/115 x^2 - 2*x - 9]
+ 
+-[2/897*x^3 - 14/299*x^2 - 1171/897*x + 9569/897 x^4 - 32*x^2 + 6]
++[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
+ 
+ [1/4485*x^3 - 7/1495*x^2 - 1034/4485*x + 7924/4485 x^4 - 8*x^2 + 6]
+ 
+ ? polred(x^4+576,1)
+-[x - 1, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
++[x - 1, x^2 - 3*x + 3, x^2 - 2*x + 2, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
+ ? polred(x^4+576,3)
+ 
+ [1 x - 1]
+ 
++[-1/192*x^3 - 1/8*x + 3/2 x^2 - 3*x + 3]
++
++[1/24*x^2 + 1 x^2 - 2*x + 2]
++
++[-1/24*x^2 + 1 x^2 - 2*x + 2]
++
+ [-1/192*x^3 - 1/8*x + 1/2 x^2 - x + 1]
+ 
++[1/192*x^3 + 1/8*x + 1/2 x^2 - x + 1]
++
+ [1/24*x^2 x^2 + 1]
+ 
+ [1/192*x^3 + 1/48*x^2 - 1/8*x x^4 - x^2 + 1]
+ 
+ ? polred(p2,0,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? polred(p2,1,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? polredabs(x^5-2*x^4-4*x^3-96*x^2-352*x-568)
+ x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1
+ ? polredabs(x^5-2*x^4-4*x^3-96*x^2-352*x-568,1)
+ [x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1, Mod(2*x^4 - x^3 + 3*x^2 - 3*x - 1, x^5 -
+  x^4 + 2*x^3 - 4*x^2 + x - 1)]
+ ? polredord(x^3-12*x+45*x-1)
+-[x - 1, x^3 - 363*x - 2663, x^3 + 33*x - 1]
++[x - 1, x^3 + 33*x - 1]
+ ? polsubcyclo(31,5)
+ x^5 + x^4 - 12*x^3 - 21*x^2 + x + 5
+ ? setrand(1);poltschirnhaus(x^5-x-1)
+@@ -1028,6 +1033,6 @@
+ ? sizebyte(%)
+ 152
+ ? getheap
+-[175, 113027]
++[175, 112999]
+ ? print("Total time spent: ",gettime);
+-Total time spent: 116
++Total time spent: 76
+diff -ruN src/src/test/64/compat b/src/test/64/compat
+--- src/src/test/64/compat	2012-09-25 23:10:47.000000000 +0200
++++ b/src/test/64/compat	2013-01-31 14:49:05.557525771 +0100
+@@ -789,13 +789,9 @@
+ ? factoreddiscf(p,fa)
+ 136866601
+ ? factoredpolred(p,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? factoredpolred2(p,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? factornf(x^3+x^2-2*x-1,t^3+t^2-2*t-1)
+ 
+ [x + mod(-t, t^3 + t^2 - 2*t - 1) 1]
+@@ -906,7 +902,7 @@
+ ? gcd(12345678,87654321)
+ 9
+ ? getheap()
+-[208, 44472]
++[208, 44308]
+ ? getrand()
+ Vecsmall([-696235626332558091, -7363039021536514678, -3123062006620239999, -
+ 2510915082749224356, -5278885121447018503, 8033304491650294704, 333461878925
+@@ -2014,7 +2010,7 @@
+ ? orderell(tcurve,[1,2])
+ 6
+ ? ordred(x^3-12*x+45*x-1)
+-[x - 1, x^3 - 363*x - 2663, x^3 + 33*x - 1]
++[x - 1, x^3 + 33*x - 1]
+ ? padicprec(padicno,127)
+ 5
+ ? pascal(8)
+@@ -2093,15 +2089,16 @@
+ ? polint([0,2,3],[0,4,9],5)
+ 25
+ ? polred(x^5-2*x^4-4*x^3-96*x^2-352*x-568)
+-[x - 1, x^5 - x^4 - 6*x^3 + 6*x^2 + 13*x - 5, x^5 - x^4 + 2*x^3 - 4*x^2 + x 
+-- 1, x^5 - x^4 + 4*x^3 - 2*x^2 + x - 1, x^5 + 4*x^3 - 4*x^2 + 8*x - 8]
++[x - 1, x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1]
+ ? polred2(x^4-28*x^3-458*x^2+9156*x-25321)
+ 
+ [1 x - 1]
+ 
+-[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
++[1/115*x^2 - 14/115*x - 212/115 x^2 - 2*x - 9]
++
++[-1/115*x^2 + 14/115*x + 442/115 x^2 - 2*x - 9]
+ 
+-[2/897*x^3 - 14/299*x^2 - 1171/897*x + 9569/897 x^4 - 32*x^2 + 6]
++[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
+ 
+ [1/4485*x^3 - 7/1495*x^2 - 1034/4485*x + 7924/4485 x^4 - 8*x^2 + 6]
+ 
+@@ -2454,13 +2451,21 @@
+ ? smallinitell([0,0,0,-17,0])
+ [0, 0, 0, -17, 0, 0, -34, 0, -289, 816, 0, 314432, 1728]
+ ? smallpolred(x^4+576)
+-[x - 1, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
++[x - 1, x^2 - 3*x + 3, x^2 - 2*x + 2, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
+ ? smallpolred2(x^4+576)
+ 
+ [1 x - 1]
+ 
++[-1/192*x^3 - 1/8*x + 3/2 x^2 - 3*x + 3]
++
++[1/24*x^2 + 1 x^2 - 2*x + 2]
++
++[-1/24*x^2 + 1 x^2 - 2*x + 2]
++
+ [-1/192*x^3 - 1/8*x + 1/2 x^2 - x + 1]
+ 
++[1/192*x^3 + 1/8*x + 1/2 x^2 - x + 1]
++
+ [1/24*x^2 x^2 + 1]
+ 
+ [1/192*x^3 + 1/48*x^2 - 1/8*x x^4 - x^2 + 1]
+@@ -2649,6 +2654,6 @@
+ ? getstack()
+ 200
+ ? getheap()
+-[599, 100048]
++[599, 100020]
+ ? print("Total time spent: ",gettime);
+-Total time spent: 152
++Total time spent: 180
+diff -ruN src/src/test/64/nfields b/src/test/64/nfields
+--- src/src/test/64/nfields	2012-09-25 23:10:47.000000000 +0200
++++ b/src/test/64/nfields	2013-01-31 14:49:05.557525771 +0100
+@@ -928,45 +928,50 @@
+ ? polgalois(x^6-3*x^2-1)
+ [12, 1, 1, "A_4(6) = [2^2]3"]
+ ? polred(x^5-2*x^4-4*x^3-96*x^2-352*x-568)
+-[x - 1, x^5 - x^4 - 6*x^3 + 6*x^2 + 13*x - 5, x^5 - x^4 + 2*x^3 - 4*x^2 + x 
+-- 1, x^5 - x^4 + 4*x^3 - 2*x^2 + x - 1, x^5 + 4*x^3 - 4*x^2 + 8*x - 8]
++[x - 1, x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1]
+ ? polred(x^4-28*x^3-458*x^2+9156*x-25321,3)
+ 
+ [1 x - 1]
+ 
+-[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
++[1/115*x^2 - 14/115*x - 212/115 x^2 - 2*x - 9]
++
++[-1/115*x^2 + 14/115*x + 442/115 x^2 - 2*x - 9]
+ 
+-[2/897*x^3 - 14/299*x^2 - 1171/897*x + 9569/897 x^4 - 32*x^2 + 6]
++[1/115*x^2 - 14/115*x - 327/115 x^2 - 10]
+ 
+ [1/4485*x^3 - 7/1495*x^2 - 1034/4485*x + 7924/4485 x^4 - 8*x^2 + 6]
+ 
+ ? polred(x^4+576,1)
+-[x - 1, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
++[x - 1, x^2 - 3*x + 3, x^2 - 2*x + 2, x^2 - x + 1, x^2 + 1, x^4 - x^2 + 1]
+ ? polred(x^4+576,3)
+ 
+ [1 x - 1]
+ 
++[-1/192*x^3 - 1/8*x + 3/2 x^2 - 3*x + 3]
++
++[1/24*x^2 + 1 x^2 - 2*x + 2]
++
++[-1/24*x^2 + 1 x^2 - 2*x + 2]
++
+ [-1/192*x^3 - 1/8*x + 1/2 x^2 - x + 1]
+ 
++[1/192*x^3 + 1/8*x + 1/2 x^2 - x + 1]
++
+ [1/24*x^2 x^2 + 1]
+ 
+ [1/192*x^3 + 1/48*x^2 - 1/8*x x^4 - x^2 + 1]
+ 
+ ? polred(p2,0,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? polred(p2,1,fa)
+-[x - 1, x^5 - 2*x^4 - 62*x^3 + 85*x^2 + 818*x + 1, x^5 - 2*x^4 - 53*x^3 - 46
+-*x^2 + 508*x + 913, x^5 - 2*x^4 - 13*x^3 + 37*x^2 - 21*x - 1, x^5 - x^4 - 52
+-*x^3 - 197*x^2 - 273*x - 127]
++[x - 1, x^5 - 80*x^3 - 223*x^2 + 800*x + 2671]
+ ? polredabs(x^5-2*x^4-4*x^3-96*x^2-352*x-568)
+ x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1
+ ? polredabs(x^5-2*x^4-4*x^3-96*x^2-352*x-568,1)
+ [x^5 - x^4 + 2*x^3 - 4*x^2 + x - 1, Mod(2*x^4 - x^3 + 3*x^2 - 3*x - 1, x^5 -
+  x^4 + 2*x^3 - 4*x^2 + x - 1)]
+ ? polredord(x^3-12*x+45*x-1)
+-[x - 1, x^3 - 363*x - 2663, x^3 + 33*x - 1]
++[x - 1, x^3 + 33*x - 1]
+ ? polsubcyclo(31,5)
+ x^5 + x^4 - 12*x^3 - 21*x^2 + x + 5
+ ? setrand(1);poltschirnhaus(x^5-x-1)
+@@ -1030,6 +1035,6 @@
+ ? sizebyte(%)
+ 288
+ ? getheap
+-[175, 102929]
++[175, 102901]
+ ? print("Total time spent: ",gettime);
+-Total time spent: 84
++Total time spent: 110

--- a/build/pkgs/pari/spkg-install
+++ b/build/pkgs/pari/spkg-install
@@ -143,14 +143,6 @@ set_environment()
     unset dfltlibdir dfltmandir dfltsysdatadir dfltobjdir
     # The following get set because we pass the respective parameters:
     # prefix kernel with_gmp with_readline
-
-    # Make flags for building (not installing) PARI/GP
-    if [ "$UNAME" = "CYGWIN" ]; then
-        # There are weird bugs in PARI's build process on Windows XP
-        # under Cygwin.
-        # Passing in these extra flags gets around the bug.
-        PARI_MAKEFLAGS="$PARI_MAKEFLAGS 'GMPINCLUDE=-I$SAGE_LOCAL/include' EXTRADLLDFLAGS=-lgmp"
-    fi
 }
 
 # Build PARI/GP
@@ -194,13 +186,6 @@ install()
         exit 1
     fi
 
-    # On Cygwin, we need the dll for PARI to be in the same
-    # directory as the gp binary, or it doesn't find it.
-    # Note that just using a symlink doesn't work.
-    if [ "$UNAME" = "CYGWIN" ]; then
-        cd "$SAGE_LOCAL"/bin/
-        cp -f "$SAGE_LOCAL"/lib/*pari*.dll .
-    fi
     cd "$CUR"
 
     if [ "$UNAME" = "Darwin" ]; then


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13054">trac #13054</a>.

Reported by: rbeezer

Component: number fields

CC: roed

Report Upstream: Fixed upstream, but not in a stable release.

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: David Roe

Merged in: sage-5.8.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13054/trac_13054-workaround.patch">trac_13054-workaround.patch: Workaround (it's really a bug in pari)</a> by nbruin at 20130130T19:57:35</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13054/pari-2.5.3.p3.diff">pari-2.5.3.p3.diff: Diff for the PARI spkg, for review only</a> by jdemeyer at 20130131T13:52:48</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13054/13054_polredbest.patch">13054_polredbest.patch: </a> by jdemeyer at 20130224T09:36:04</li></ol>
