### PR TITLE
PolyBoRi should depend on IPython

### DIFF
--- a/build/standard/deps
+++ b/build/standard/deps
@@ -239,9 +239,9 @@ $(INST)/$(FPLLL): $(INST)/$(MPIR) $(INST)/$(MPFR)
 $(INST)/$(PARI): $(INST)/$(READLINE) $(INST)/$(MPIR)
 	+$(PIPE) "$(SAGE_SPKG) $(PARI) 2>&1" "tee -a $(SAGE_LOGS)/$(PARI).log"
 
-$(INST)/$(POLYBORI): $(INST)/$(PYTHON) $(INST)/$(SCONS) \
-		     $(INST)/$(BOOST_CROPPED) $(INST)/$(M4RI) \
-		     $(INST)/$(GD)
+$(INST)/$(POLYBORI): $(INST)/$(PYTHON) $(INST)/$(IPYTHON) \
+         $(INST)/$(SCONS) $(INST)/$(BOOST_CROPPED) \
+         $(INST)/$(M4RI) $(INST)/$(GD)
 	+$(PIPE) "$(SAGE_SPKG) $(POLYBORI) 2>&1" "tee -a $(SAGE_LOGS)/$(POLYBORI).log"
 
 # POLYTOPES_DB depends on SAGE_ROOT_REPO because it needs SAGE_SHARE


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14026">trac #14026</a>.

Reported by: jdemeyer

Component: build

CC: vbraun

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Alexander Dreyer

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14026/14026_polybori_deps.patch">14026_polybori_deps.patch: </a> by jdemeyer at 20130128T13:18:56</li></ol>
