### PR TITLE
if build fails, print message about which spkgs failed

### DIFF
--- a/build/install
+++ b/build/install
@@ -511,7 +511,34 @@ echo "***********************************************"
 ###############################################################################
 time $MAKE "$@"
 if [ $? -ne 0 ]; then
-    echo >&2 "Error building Sage."
+    cat >&2 <<EOF
+***************************************************************
+Error building Sage.
+
+The following package(s) may have failed to build:
+EOF
+
+    for f in "$SAGE_LOGS"/*.log; do
+        # Look for recent error message in log file.
+        # Note that "tail -n 20 ..." doesn't work on Solaris.
+        if tail -20 "$f" | grep "^Error" &>/dev/null; then
+            base_f=`basename $f .log`
+            cat >&2 <<EOF
+
+package: $base_f
+log file: $f
+build directory: ${SAGE_BUILD_DIR:-$SAGE_ROOT/spkg/build}/$base_f
+EOF
+        fi
+    done
+    cat >&2 <<EOF
+
+The build directory may contain configuration files and other potentially
+helpful information. WARNING: if you now run 'make' again, the build
+directory will, by default, be deleted. Set the environment variable
+SAGE_KEEP_BUILT_SPKGS to 'yes' to prevent this.
+
+EOF
     exit 1
 fi
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14263">trac #14263</a>.

root repo

Reported by: jhpalmieri

Component: build

CC: leif,, vbraun

Report Upstream: N/A

Authors: John Palmieri

Dependencies: 

Work issues: 

Reviewers: Volker Braun

Merged in: sage-5.9.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14263/trac_14263_sage_root.v2.patch">trac_14263_sage_root.v2.patch: root repo</a> by jhpalmieri at 20130314T23:22:56</li></ol>
