### PR TITLE
Upgrade MPIR to 2.6.0

### DIFF
--- a/build/pkgs/mpir/SPKG.txt
+++ b/build/pkgs/mpir/SPKG.txt
@@ -50,11 +50,11 @@ See http://www.mpir.org
 
 == Changelog ==
 
-=== mpir-2.6.0.p0 (Jean-Pierre Flori, 25 November 2012) ===
+=== mpir-2.6.0.p0 (Jean-Pierre Flori, 12 January 2013) ===
  * Trac #13137: Update to MPIR 2.6.0.
  * Modify spkg-install to rename *,asm files to *.asm files.
  * Remove -Wl,-z,noexecstack fix which has been integrated upstream.
- * Remove old code about 32 bits Apple Darwin and use upstream fix.
+ * Remove old code about 32 bits Apple Darwin and use slightly modified upstream fix.
 
 === mpir-2.5.2.p0 (John Palmieri, 3 October 2012) ===
  * Trac #13137: Update to MPIR 2.5.2.

--- a/build/pkgs/mpir/spkg-install
+++ b/build/pkgs/mpir/spkg-install
@@ -19,7 +19,7 @@ cd src/
 # detecting filename changes. See Trac #13137.
 # This fix can (and will have to) be removed once integrated upstream.
 echo "Renaming *,asm files to *.asm..."
-mv mpn/x86/p6/addmul_1,asm mpn/x86/p6/addmul_1.asm
+mv mpn/x86/p6/addmul_1,asm mpn/x86/p6/addmul_1.asm &&
 mv mpn/x86/p6/submul_1,asm mpn/x86/p6/submul_1.asm
 if [ $? -ne 0 ]; then
     echo >&2 "Error: moving *,asm files failed."
@@ -199,15 +199,15 @@ if [ "$SAGE_BUILD_TOOLCHAIN" = yes ]; then
     echo "Building a reduced version of MPIR to bootstrap GCC."
     echo "MPIR will later get rebuilt (with the C++ interface and static libraries"
     echo "enabled) using the new compiler."
-    MPIR_CONFIGURE="--disable-cxx --disable-static $MPIR_CONFIGURE"
+    MPIR_CONFIGURE="$MPIR_CONFIGURE --disable-cxx --disable-static"
     SAGE_FAT_BINARY=no
 else
     # Also build the static library to be used by e.g. ECM
     # unless we are on Cygwin where we can only build a shared
-    # or a static library but not both
+    # or a static library but not both:
     if [ "$UNAME" = "CYGWIN" ]; then
-        echo "Building MPIR with the C++ interface."
-        MPIR_CONFIGURE="--enable-cxx --disable-static $MPIR_CONFIGURE"
+        echo "Building MPIR with the C++ interface and (only) shared libraries."
+        MPIR_CONFIGURE="--enable-cxx $MPIR_CONFIGURE --disable-static"
     else
         echo "Building MPIR with the C++ interface and (also) static libraries."
         MPIR_CONFIGURE="--enable-cxx --enable-static $MPIR_CONFIGURE"


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13137">trac #13137</a>.

Spkg diff, for review only.

Reported by: jhpalmieri

Component: packages

CC: jpflori

Report Upstream: N/A

Authors: John Palmieri, Jean-Pierre Flori, Karl-Dieter Crisman

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/13755">trac #13755</a>

Work issues: 

Reviewers: Jeroen Demeyer, Leif Leonhardy, John Palmieri, R. Andrew Ohana, Karl-Dieter Crisman

Merged in: sage-5.7.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13137/trac_13137-stopgap.patch">trac_13137-stopgap.patch: root repo</a> by jhpalmieri at 20120619T20:37:37</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13137/trac_13137-mpir.patch">trac_13137-mpir.patch: patch for mpir spkg; for review only</a> by jhpalmieri at 20120820T18:56:57</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13137/trac_13137-mpir-2.5.2.patch">trac_13137-mpir-2.5.2.patch: patch for mpir 2.5.2 spkg</a> by jhpalmieri at 20121003T21:52:48</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13137/mpir-2.6.0.p0.diff">mpir-2.6.0.p0.diff: Spkg diff, for review only.</a> by jpflori at 20130111T15:44:04</li></ol>
