### PR TITLE
Let iconv build on Cygwin without installing Cygwin libiconv package

### DIFF
--- a/build/pkgs/iconv/SPKG.txt
+++ b/build/pkgs/iconv/SPKG.txt
@@ -23,6 +23,9 @@ languages, with different characters to be handled properly.
 
 == Changelog ==
 
+=== iconv-1.13.1.p4 (Jean-Pierre Flori, 5 January 2013) ===
+ * #13912: let iconv build on Cygwin without additional prereqs.
+
 === iconv-1.13.1.p3 (David Kirkby, August 10th, 2010) ===
  * Use '$MAKE' instead of 'make' in spkg-install and spkg-check to enable
    parallel builds, and allow the user to specify a different 'make' program.

--- a/build/pkgs/iconv/spkg-install
+++ b/build/pkgs/iconv/spkg-install
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 if [ -z "$SAGE_LOCAL" ]; then
-    echo "SAGE_LOCAL undefined ... exiting"
-    echo "Maybe run 'sage -sh'?"
+    echo >&2 "SAGE_LOCAL undefined ... exiting"
+    echo >&2 "Maybe run 'sage -sh'?"
     exit 1
 fi
 
@@ -36,23 +36,29 @@ CYGWIN|HP-UX|SunOS)
         export CC
     fi
 
+    # Disable NLS on Cygwin to be able to build libiconv without the Cygwin
+    # libiconv package.
+    if [ "$UNAME" = "CYGWIN" ]; then
+        ICONV_CONFIGURE="--disable-nls $ICONV_CONFIGURE"
+    fi
+
     cd src
 
-    ./configure --prefix="$SAGE_LOCAL"
+    ./configure --prefix="$SAGE_LOCAL" --libdir="$SAGE_LOCAL/lib" $ICONV_CONFIGURE
     if [ $? -ne 0 ]; then
-        echo "Error configuring iconv"
+        echo >&2 "Error configuring iconv"
         exit 1
     fi
 
     $MAKE
     if [ $? -ne 0 ]; then
-        echo "Error building iconv"
+        echo >&2 "Error building iconv"
         exit 1
     fi
 
     $MAKE install
     if [ $? -ne 0 ]; then
-        echo "Error installing iconv"
+        echo >&2 "Error installing iconv"
         exit 1
     fi
     exit 0


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13912">trac #13912</a>.

Spkg diff, for review only.

Reported by: jpflori

Component: packages

CC: kcrisman

Report Upstream: N/A

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.7.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13912/iconv-1.13.1.p4.diff">iconv-1.13.1.p4.diff: Spkg diff, for review only.</a> by jpflori at 20130113T13:25:26</li></ol>
