### PR TITLE
Fix cython's gc_track and gc_untrack

### DIFF
--- a/build/pkgs/cython/SPKG.txt
+++ b/build/pkgs/cython/SPKG.txt
@@ -31,10 +31,13 @@ Apache License, Version 2.0
 
 == Changelog ==
 
-=== cython-0.17.3 (Volker Braun, 14 December 2012) ===
+=== cython-0.17.4 (Robert Bradshaw, 4 January 2013, #13896) ===
+ * Upgrade Cython 0.17.4
+
+=== cython-0.17.3 (Volker Braun, 14 December 2012, #13832) ===
  * Upgrade Cython 0.17.3
 
-=== cython-0.17.2 (Volker Braun, 21 November 2012) ===
+=== cython-0.17.2 (Volker Braun, 21 November 2012, #13740) ===
  * Upgrade Cython 0.17.2
 
 === cython-0.17pre (Robert Bradshaw, 25 June 2012, #13029) ===


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13896">trac #13896</a>.

Robert's cython test case (I spent quite some time twice to find it, so I'm storing it here for future reference)

Reported by: nbruin

Component: memleak

CC: SimonKing,, jpflori

Report Upstream: Completely fixed; Fix reported upstream

Authors: Robert Bradshaw

Dependencies: 

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.6.beta3

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13896/double-free-crash.patch">double-free-crash.patch: Patch to more reliably produce crash</a> by nbruin at 20130101T18:53:17</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13896/cython-0.17.3.p0.diff">cython-0.17.3.p0.diff: </a> by jpflori at 20130102T19:54:51</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13896/double_dealloc_T796.pyx">double_dealloc_T796.pyx: Robert's cython test case (I spent quite some time twice to find it, so I'm storing it here for future reference)</a> by nbruin at 20130103T21:09:37</li></ol>
