### PR TITLE
Slowdown for PARI integer determinant

### DIFF
--- a/build/pkgs/pari/SPKG.txt
+++ b/build/pkgs/pari/SPKG.txt
@@ -69,18 +69,22 @@ of doubt, have a look at the file spkg-src.
 
 == Changelog ==
 
+=== pari-2.5.3.p1 (Jeroen Demeyer, 3 January 2013) ===
+ * Trac #13902: add a patch (backported from upstream PARI 2.6.0)
+   for integer determinants.
+
 === pari-2.5.3.p0 (Jeroen Demeyer, 5 October 2012) ===
- * Ticket #13534: upgrade to version 2.5.3
+ * Trac #13534: upgrade to version 2.5.3
  * Remove upstreamed patch rootpol.patch
 
 === pari-2.5.2.p2 (Jean-Pierre Flori, 30 September 2012) ===
- * Ticket #13333: add upstream patch to copy libpari.dll.a on Cygwin.
+ * Trac #13333: add upstream patch to copy libpari.dll.a on Cygwin.
 
 === pari-2.5.2.p1 (Paul Zimmermann, 28 August 2012) ===
- * Ticket #13314: add upstream patch rootpol.patch for rootpol().
+ * Trac #13314: add upstream patch rootpol.patch for rootpol().
 
 === pari-2.5.2.p0 (Jeroen Demeyer, 1 August 2012) ===
- * Ticket #13320: upgrade to version 2.5.2
+ * Trac #13320: upgrade to version 2.5.2
  * Rename spkg-make to spkg-src
  * Remove various upstreamed patches:
     - pari_1302.patch
@@ -88,30 +92,30 @@ of doubt, have a look at the file spkg-src.
     - reorder_init_opts.patch
 
 === pari-2.5.1.p3 (Jeroen Demeyer, 20 March 2012) ===
- * Ticket #12638: add upstream patch pari_1304.patch for issquarefree(0),
+ * Trac #12638: add upstream patch pari_1304.patch for issquarefree(0),
    see http://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=1304
 
 === pari-2.5.1.p2 (Jeroen Demeyer, 13 March 2012) ===
- * Ticket #12638: add upstream patch pari_1302.patch for ispower(),
+ * Trac #12638: add upstream patch pari_1302.patch for ispower(),
    see http://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=1302
  * Apply all patches at -p1 level instead of -p0 (just like most other
    Sage packages).
 
 === pari-2.5.1.p1 (Jeroen Demeyer, 7 March 2012) ===
- * Ticket #12638: add patch GCC_PR49330.patch to work around a bug
+ * Trac #12638: add patch GCC_PR49330.patch to work around a bug
    in gcc-4.6.3 on OS X 10.4 PPC.
 
 === pari-2.5.1.p0 (Jeroen Demeyer, 11 February 2012) ===
- * Ticket #12363: upgrade to PARI 2.5.1.
+ * Trac #12363: upgrade to PARI 2.5.1.
  * Use git instead of svn in spkg-make to obtain the PARI sources.
  * Remove upstreamed patch osx_13318_13330.patch.
 
 === pari-2.5.0.p3 (Jeroen Demeyer, 20 December 2011) ===
- * Ticket #12158: add reorder_init_opts.patch such that warnings
+ * Trac #12158: add reorder_init_opts.patch such that warnings
    during pari_init_opts() do not cause segfaults.
 
 === pari-2.5.0.p2 (Jeroen Demeyer, 26 July 2011) ===
- * Ticket #11130: update to PARI stable version 2.5.0, which is
+ * Trac #11130: update to PARI stable version 2.5.0, which is
    equal to svn version 13228.
  * Moving to this upstream version fixes #10195, #10767, #11604.
  * Remove all previous upstream patches.
@@ -120,13 +124,12 @@ of doubt, have a look at the file spkg-src.
    Mac OS X.
 
 === pari-2.4.3.alpha.p7 (Leif Leonhardy, July 16th, 2011) ===
- * #11605: Fix typo in spkg-install and add `exit 1` (again) in case
-   the build fails.
+ * Trac #11605: Fix typo in spkg-install and add `exit 1` (again) in
+   case the build fails.
  * Quote some more variables and filenames in messages.
 
 === pari-2.4.3.alpha.p6 (Dima Pasechnik, 22 April, 2011) ===
- * made a proper check for libpari.dll on Cygwin, as described in
-   trac #10240
+ * Trac #10240: made a proper check for libpari.dll on Cygwin.
 
 === pari-2.4.3.alpha.p5 (Jeroen Demeyer, January 23th, 2011) ===
  * Avoid parallel "make install" because of race conditions.
@@ -134,7 +137,7 @@ of doubt, have a look at the file spkg-src.
    conditions in "make install".
 
 === pari-2.4.3.alpha.p4 (Jeroen Demeyer, January 11th, 2011) ===
- * Ticket #10430 (fixing also #9620, #10279, #10369, #10559)
+ * Trac #10430 (fixing also #9620, #10279, #10369, #10559)
  * Use `patch` to apply patches (at -p0 level because this is how svn
    gives the diffs).
  * Apply patches for PARI bugs 1084, 1132, 1141, 1143, 1144.

--- a/build/pkgs/pari/patches/README.txt
+++ b/build/pkgs/pari/patches/README.txt
@@ -43,3 +43,7 @@ C files:
   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=49330
   This bug manifests itself as a Bus Error on OS X 10.4 PPC with
   gcc-4.6.3.
+* trac_13902_determinant.patch: patch backported from upstream git
+  repository based on commits
+  - 28ea998bc661f5bbde18b6d6b0f50111a10ae16c
+  - 249432f7088bfa114ed5cd3a5d64ef51ee968e35

--- a/build/pkgs/pari/patches/trac_13902_determinant.patch
+++ b/build/pkgs/pari/patches/trac_13902_determinant.patch
@@ -1,0 +1,100 @@
+diff -ru src/src/basemath/alglin1.c b/src/basemath/alglin1.c
+--- src/src/basemath/alglin1.c	2012-09-25 23:10:46.000000000 +0200
++++ b/src/basemath/alglin1.c	2013-01-03 13:56:55.487513420 +0100
+@@ -2969,6 +2969,21 @@
+   return NULL; /* not reached */
+ }
+ 
++/* A a 2x2 matrix
++   returns the determinant of A computed by the simple formula
++*/
++static GEN
++det2x2(GEN A)
++{
++  pari_sp av = avma;
++  GEN a = gcoeff(A, 1, 1),
++      b = gcoeff(A, 1, 2),
++      c = gcoeff(A, 2, 1),
++      d = gcoeff(A, 2, 2);
++  return gerepileupto(av, gsub(gmul(a, d), gmul(b, c)));
++}
++
++
+ static GEN
+ det_simple_gauss(GEN a, GEN data, pivot_fun pivot)
+ {
+@@ -3021,6 +3036,7 @@
+   if (typ(a)!=t_MAT) pari_err(mattype1,"det2");
+   if (!nbco) return gen_1;
+   if (nbco != lg(a[1])-1) pari_err(mattype1,"det2");
++  if (nbco == 2) return det2x2 (a);
+   pivot = get_pivot_fun(a, &data);
+   return det_simple_gauss(a, data, pivot);
+ }
+@@ -3158,11 +3174,7 @@
+   {
+     case 0: return gen_1;
+     case 1: return gcopy(gcoeff(M,1,1));
+-    case 2: {
+-      GEN a = gcoeff(M,1,1), b = gcoeff(M,1,2);
+-      GEN c = gcoeff(M,2,1), d = gcoeff(M,2,2);
+-      return gerepileupto(av, gsub(gmul(a,d), gmul(b,c)));
+-    }
++    case 2: return det2x2(M);
+   }
+   if (max > ((n+2)>>1)) max = (n+2)>>1;
+   for (j = 1; j <= n; j++)
+@@ -3193,9 +3205,10 @@
+   }
+   if (best_row)
+   {
++    double d = lbest-1;
+     GEN s = NULL;
+     long k;
+-    bound /= (lbest-1);
++    bound /= d*d*d;
+     for (k = 1; k < lbest; k++)
+     {
+       GEN c = coeff_det(M, best_row, best[k], max, bound);
+@@ -3205,9 +3218,10 @@
+   }
+   if (best_col)
+   {
++    double d = lbest-1;
+     GEN s = NULL;
+     long k;
+-    bound /= (lbest-1);
++    bound /= d*d*d;
+     for (k = 1; k < lbest; k++)
+     {
+       GEN c = coeff_det(M, best[k], best_col, max, bound);
+@@ -3230,15 +3244,24 @@
+   if (!n) return gen_1;
+   if (n != lg(a[1])-1) pari_err(mattype1,"det");
+   if (n == 1) return gcopy(gcoeff(a,1,1));
+-  if (RgM_is_FpM(a, &p) && p)
++  if (RgM_is_FpM(a, &p))
+   {
+-    pari_sp av = avma;
+-    return gerepilecopy(av, Fp_to_mod(FpM_det(RgM_to_FpM(a, p), p), p));
++    pari_sp av;
++    if (!p)
++    { /* ZM */
++      return det_simple_gauss(a, NULL, &gauss_get_pivot_NZ);
++    }
++    else
++    { /* FpM */
++      av = avma;
++      return gerepilecopy(av, Fp_to_mod(FpM_det(RgM_to_FpM(a, p), p), p));
++    }
+   }
++  if (n == 2) return det2x2 (a);
+   pivot = get_pivot_fun(a, &data);
+   if (pivot != gauss_get_pivot_NZ) return det_simple_gauss(a, data, pivot);
+-  B = (double)n; B = B*B; B = B*B;
+-  return det_develop(a, 7, B);
++  B = (double)n;
++  return det_develop(a, 7, B*B*B);
+ }
+ 
+ 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13902">trac #13902</a>.

Diff for the PARI spkg, for review only

Reported by: azi

Component: packages

CC: jdemeyer

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Volker Braun

Merged in: sage-5.6.beta3

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13902/pari-2.5.3.p1.diff">pari-2.5.3.p1.diff: Diff for the PARI spkg, for review only</a> by jdemeyer at 20130103T13:06:21</li></ol>
