### PR TITLE
Resolve ecl.dll conflict on Cygwin

### DIFF
--- a/build/pkgs/ecl/SPKG.txt
+++ b/build/pkgs/ecl/SPKG.txt
@@ -68,6 +68,11 @@ Website: http://ecls.sourceforge.net/
 
 == Changelog ==
 
+=== ecl-12.12.1.p1 (Jean-Pierre Flori, 18 December 2012) ===
+ * #9167: Resolve ecl.dll conflict on Cygwin.
+ * Add a patch (implib.patch) to follow usual naming scheme for dlls on Cygwin
+   and generate an import library.
+
 === ecl-12.12.1.p0 (Jean-Pierre Flori, 15 December 2012) ===
  * #13324: upgrade to upstream version 12.12.1.
  * Remove patches (cygwin.patch, signal.patch) which have been integrated

--- a/build/pkgs/ecl/patches/implib.patch
+++ b/build/pkgs/ecl/patches/implib.patch
@@ -1,0 +1,246 @@
+diff -durN src.orig/src/configure.in src/src/configure.in
+--- src.orig/src/configure.in	2012-12-17 11:08:10.000000000 +0100
++++ src/src/configure.in	2013-01-18 11:34:30.012132746 +0100
+@@ -576,6 +576,19 @@
+ AC_SUBST(SONAME)
+ AC_SUBST(SONAME_LDFLAGS)
+ 
++dnl ----------------------------------------------------------------------
++dnl IMPLIB_NAME is only active when IMPLIB_NAME is non nil
++dnl
++AC_MSG_CHECKING(for import name)
++if test "${enable_soname}" != yes; then
++   IMPLIB_NAME=''
++   AC_MSG_RESULT([none])
++else
++   AC_MSG_RESULT([${IMPLIB_NAME}])
++fi
++AC_SUBST(IMPLIB_NAME)
++AC_SUBST(IMPLIB_LDFLAGS)
++
+ dnl Related to that, the package version number
+ ECL_VERSION_NUMBER=$(($PACKAGE_MAJOR * 10000 + $PACKAGE_MINOR * 100 + $PACKAGE_LEAST))
+ AC_SUBST(ECL_VERSION_NUMBER)
+diff -durN src.orig/src/Makefile.in src/src/Makefile.in
+--- src.orig/src/Makefile.in	2012-12-17 11:08:06.000000000 +0100
++++ src/src/Makefile.in	2013-01-18 11:34:30.012132746 +0100
+@@ -174,10 +174,14 @@
+ 	  if test -s $$i ; then \
+ 	   if echo $$i | grep dll; then \
+ 	    $(INSTALL_LIBRARY) $$i $(DESTDIR)$(bindir); \
+-	   fi; \
+-	   $(INSTALL_LIBRARY) $$i $(DESTDIR)$(libdir); \
++	   else \
++	    $(INSTALL_LIBRARY) $$i $(DESTDIR)$(libdir); \
++	   fi \
+ 	  fi \
+ 	done
++	if [ "x@IMPLIB_NAME@" != "x" -a -f "@IMPLIB_NAME@" ]; then \
++	  $(INSTALL_LIBRARY) @IMPLIB_NAME@ $(DESTDIR)$(libdir); \
++	fi
+ 	if [ "x@SONAME@" != "x" -a -f "@SONAME@" ]; then \
+ 	  ( cd $(DESTDIR)$(libdir) && $(RM) -f @SONAME3@ @SONAME2@ @SONAME1@ && \
+ 	    mv @SONAME@ @SONAME3@ && \
+diff -durN src.orig/src/compile.lsp.in src/src/compile.lsp.in
+--- src.orig/src/compile.lsp.in	2012-12-17 11:08:05.000000000 +0100
++++ src/src/compile.lsp.in	2013-01-18 11:34:30.012132746 +0100
+@@ -42,7 +42,7 @@
+ ;;;
+ ;;; * Add include path to not yet installed headers, and remove include flag
+ ;;;   (-I) to installed directory, and Notice that we must explicitely mention
+-;;;   libecl.so/ecl.dll instead of using -lecl. This is to avoid interference
++;;;   libecl.so/cygecl.dll instead of using -lecl. This is to avoid interference
+ ;;;   with an already installed copy of ECL.
+ ;;;
+ (setq c::*cc-flags*
+@@ -50,7 +50,7 @@
+       #+msvc "@CFLAGS@ @ECL_CFLAGS@"
+       c::*ecl-include-directory* "@true_builddir@/"
+       c::*ecl-library-directory* "@true_builddir@/")
+-#-:wants-dlopen 
++#-:wants-dlopen
+ (setf c::*ld-flags*
+       "@LDFLAGS@ @LIBPREFIX@ecl.@LIBEXT@ @CORE_LIBS@ @LIBS@ @FASL_LIBS@")
+ #+(and :wants-dlopen (not nonstop))
+@@ -124,7 +124,7 @@
+ ;;;
+ ;;; We do not need the -rpath flag for the library, nor -lecl.
+ ;;;
+-(let* ((c::*ld-shared-flags* #-msvc "@SHARED_LDFLAGS@ @LDFLAGS@ @SONAME_LDFLAGS@ @CORE_LIBS@ @LIBS@ @FASL_LIBS@"
++(let* ((c::*ld-shared-flags* #-msvc " @IMPLIB_LDFLAGS@ @SHARED_LDFLAGS@ @LDFLAGS@ @SONAME_LDFLAGS@ @CORE_LIBS@ @LIBS@ @FASL_LIBS@"
+ 			     #+msvc "@SHARED_LDFLAGS@ @LDFLAGS@ @STATICLIBS@ @CLIBS@")
+        (c::*cc-flags* (concatenate 'string "-DECL_API -I@true_builddir@/c " c::*cc-flags*))
+        (extra-args nil))
+diff -durN src.orig/src/aclocal.m4 src/src/aclocal.m4
+--- src.orig/src/aclocal.m4	2012-12-17 11:08:05.000000000 +0100
++++ src/src/aclocal.m4	2013-01-18 11:34:30.012132746 +0100
+@@ -232,6 +232,8 @@
+ AC_SUBST(LIBEXT)
+ AC_SUBST(SHAREDEXT)dnl	Name components of a dynamically linked library
+ AC_SUBST(SHAREDPREFIX)
++AC_SUBST(IMPLIB_EXT)dnl	Name components of a dynamically linked library import file
++AC_SUBST(IMPLIB_PREFIX)
+ AC_SUBST(OBJEXT)dnl	These are set by autoconf
+ AC_SUBST(EXEEXT)
+ AC_SUBST(INSTALL_TARGET)dnl Which type of installation: flat directory or unix like.
+@@ -241,6 +243,8 @@
+ ECL_LDRPATH=''
+ SHAREDEXT='so'
+ SHAREDPREFIX='lib'
++IMPLIB_EXT=''
++IMPLIB_PREFIX=''
+ LIBPREFIX='lib'
+ LIBEXT='a'
+ PICFLAG='-fPIC'
+@@ -252,6 +256,8 @@
+ clibs=''
+ SONAME=''
+ SONAME_LDFLAGS=''
++IMPLIB_NAME=''
++IMPLIB_LDFLAGS=''
+ case "${host_os}" in
+ 	# libdir may have a dollar expression inside
+ 	linux*)
+@@ -354,10 +360,14 @@
+ 		shared='yes'
+ 		THREAD_CFLAGS='-D_THREAD_SAFE'
+ 		THREAD_LIBS='-lpthread'
+-		SHARED_LDFLAGS="-shared ${LDFLAGS}"
+-		BUNDLE_LDFLAGS="-shared ${LDFLAGS}"
+-		SHAREDPREFIX=''
++		SHARED_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
++		BUNDLE_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
++		SHAREDPREFIX='cyg'
+ 		SHAREDEXT='dll'
++		IMPLIB_PREFIX='lib'
++		IMPLIB_EXT='dll.a'
++		IMPLIB_NAME="${IMPLIB_PREFIX}ecl.${IMPLIB_EXT}"
++		IMPLIB_LDFLAGS="-Wl,--out-implib,${IMPLIB_NAME}"
+ 		PICFLAG=''
+ 		;;
+ 	mingw*)
+@@ -367,10 +377,14 @@
+                 enable_threads='yes'
+ 		THREAD_CFLAGS='-D_THREAD_SAFE'
+ 		THREAD_GC_FLAGS='--enable-threads=win32'
+-		SHARED_LDFLAGS=''
+-		BUNDLE_LDFLAGS=''
++		SHARED_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
++		BUNDLE_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
+ 		SHAREDPREFIX=''
+ 		SHAREDEXT='dll'
++		IMPLIB_PREFIX='lib'
++		IMPLIB_EXT='dll.a'
++		IMPLIB_NAME="${IMPLIB_PREFIX}ecl.${IMPLIB_EXT}"
++		IMPLIB_LDFLAGS="-Wl,--out-implib,${IMPLIB_NAME}"
+ 		PICFLAG=''
+ 		INSTALL_TARGET='flatinstall'
+ 		TCPLIBS='-lws2_32'
+diff -durN src.orig/src/configure src/src/configure
+--- src.orig/src/configure	2012-12-17 11:08:11.000000000 +0100
++++ src/src/configure	2013-01-18 11:35:15.231702758 +0100
+@@ -643,6 +643,8 @@
+ CL_FIXNUM_TYPE
+ XMKMF
+ ECL_VERSION_NUMBER
++IMPLIB_LDFLAGS
++IMPLIB_NAME
+ SONAME_LDFLAGS
+ SONAME
+ SONAME1
+@@ -659,6 +661,8 @@
+ ECL_GC_DIR
+ thehost
+ INSTALL_TARGET
++IMPLIB_PREFIX
++IMPLIB_EXT
+ SHAREDPREFIX
+ SHAREDEXT
+ LIBEXT
+@@ -4844,10 +4848,13 @@
+ 
+ 
+ 
++
+ ECL_GC_DIR=gc-unstable
+ ECL_LDRPATH=''
+ SHAREDEXT='so'
+ SHAREDPREFIX='lib'
++IMPLIB_EXT=''
++IMPLIB_PREFIX=''
+ LIBPREFIX='lib'
+ LIBEXT='a'
+ PICFLAG='-fPIC'
+@@ -4859,6 +4866,8 @@
+ clibs=''
+ SONAME=''
+ SONAME_LDFLAGS=''
++IMPLIB_NAME=''
++IMPLIB_LDFLAGS=''
+ case "${host_os}" in
+ 	# libdir may have a dollar expression inside
+ 	linux*)
+@@ -4961,10 +4970,14 @@
+ 		shared='yes'
+ 		THREAD_CFLAGS='-D_THREAD_SAFE'
+ 		THREAD_LIBS='-lpthread'
+-		SHARED_LDFLAGS="-shared ${LDFLAGS}"
+-		BUNDLE_LDFLAGS="-shared ${LDFLAGS}"
+-		SHAREDPREFIX=''
++		SHARED_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
++		BUNDLE_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
++		SHAREDPREFIX='cyg'
+ 		SHAREDEXT='dll'
++		IMPLIB_PREFIX='lib'
++		IMPLIB_EXT='dll.a'
++		IMPLIB_NAME="${IMPLIB_PREFIX}ecl.${IMPLIB_EXT}"
++		IMPLIB_LDFLAGS="-Wl,--out-implib,${IMPLIB_NAME}"
+ 		PICFLAG=''
+ 		;;
+ 	mingw*)
+@@ -4974,10 +4987,14 @@
+                 enable_threads='yes'
+ 		THREAD_CFLAGS='-D_THREAD_SAFE'
+ 		THREAD_GC_FLAGS='--enable-threads=win32'
+-		SHARED_LDFLAGS=''
+-		BUNDLE_LDFLAGS=''
++		SHARED_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
++		BUNDLE_LDFLAGS="-shared -Wl,--enable-auto-image-base ${LDFLAGS}"
+ 		SHAREDPREFIX=''
+ 		SHAREDEXT='dll'
++		IMPLIB_PREFIX='lib'
++		IMPLIB_EXT='dll.a'
++		IMPLIB_NAME="${IMPLIB_PREFIX}ecl.${IMPLIB_EXT}"
++		IMPLIB_LDFLAGS="-Wl,--out-implib,${IMPLIB_NAME}"
+ 		PICFLAG=''
+ 		INSTALL_TARGET='flatinstall'
+ 		TCPLIBS='-lws2_32'
+@@ -6120,6 +6137,19 @@
+ 
+ 
+ 
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for import name" >&5
++$as_echo_n "checking for import name... " >&6; }
++if test "${enable_soname}" != yes; then
++   IMPLIB_NAME=''
++   { $as_echo "$as_me:${as_lineno-$LINENO}: result: none" >&5
++$as_echo "none" >&6; }
++else
++   { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${IMPLIB_NAME}" >&5
++$as_echo "${IMPLIB_NAME}" >&6; }
++fi
++
++
++
+ ECL_VERSION_NUMBER=$(($PACKAGE_MAJOR * 10000 + $PACKAGE_MINOR * 100 + $PACKAGE_LEAST))
+ 
+ 
+@@ -10006,7 +10036,7 @@
+ configured by $0, generated by GNU Autoconf 2.69,
+   with options \\"\$ac_cs_config\\"
+ 
+-Copyright (C) 2012 Free Software Foundation, Inc.
++Copyright (C)  Free Software Foundation, Inc.
+ This config.status script is free software; the Free Software Foundation
+ gives unlimited permission to copy, distribute and modify it."
+ 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/9167">trac #9167</a>.

Spkg diff, for review only.

Reported by: was

Component: cygwin

CC: mhansen,, dimpase,, jpflori,, jdemeyer

Report Upstream: None of the above - read trac for reasoning.

Authors: Jean-Pierre Flori

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/13324">trac #13324</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/13860">trac #13860</a>

Work issues: 

Reviewers: Karl-Dieter Crisman, Jeroen Demeyer

Merged in: sage-5.7.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9167/spkg.diff">spkg.diff: Spkg diff, for review only. Not committed in spkg.</a> by jpflori at 20120820T16:53:45</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9167/spkg-take2.diff">spkg-take2.diff: For review only - based on JP's spkg</a> by kcrisman at 20121206T17:01:12</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9167/implib.patch">implib.patch: Patch to upstream build system.</a> by jpflori at 20121218T17:14:23</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9167/ecl-12.12.1.p1.diff">ecl-12.12.1.p1.diff: Spkg diff, for review only.</a> by jpflori at 20130118T10:54:08</li></ol>
