### PR TITLE
cvxopt needs to link against gmp/mpir on 32-bit Windows XP Cygwin

### DIFF
--- a/build/pkgs/cvxopt/SPKG.txt
+++ b/build/pkgs/cvxopt/SPKG.txt
@@ -26,6 +26,7 @@ programming language.
 Downloaded from http://abel.ee.ucla.edu/cvxopt/
 
 == License ==
+
 GPLv3 or later. Includes parts under GPLv2,
 GNU Lesser General Public License, v2.1.  See src/LICENSE for more details.
 (Sage-compatible)
@@ -53,8 +54,11 @@ GNU Lesser General Public License, v2.1.  See src/LICENSE for more details.
 
 == Changelog ==
 
+=== cvxopt-1.1.5.p0 (Jean-Pierre Flori, 5 December 2012) ===
+ * #13799: add back linking dependencies removed by #13160 and needed on Cygwin.
+
 === cvxopt-1.1.5 (François Bissey, 25 June 2012) ===
- * update to 1.1.5, drop dense.c patch as it is not needed anymore.
+ * #13160: update to 1.1.5, drop dense.c patch as it is not needed anymore.
  * rewrite and simplify the patch for setup.py. Keep the necessary linking minimal.
  * First attempt at doc building
 

--- a/build/pkgs/cvxopt/patches/setup.py.patch
+++ b/build/pkgs/cvxopt/patches/setup.py.patch
@@ -63,3 +63,12 @@
  
  # Set to 1 if you are installing the DSDP module.
  BUILD_DSDP = 0
+@@ -77,7 +87,7 @@
+     extmods += [fftw];
+ 
+ if BUILD_GLPK:
++    glpk = Extension('glpk', libraries = ['glpk', 'gmp', 'z'],
+-    glpk = Extension('glpk', libraries = ['glpk'],
+         include_dirs = [ GLPK_INC_DIR ],
+         library_dirs = [ GLPK_LIB_DIR ],
+         sources = ['C/glpk.c'] )


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13799">trac #13799</a>.

Spkg diff, for review only.

Reported by: kcrisman

Component: cygwin

CC: jpflori

Report Upstream: N/A

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Karl-Dieter Crisman

Merged in: sage-5.6.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13799/cvxopt-1.1.5.p0.diff">cvxopt-1.1.5.p0.diff: Spkg diff, for review only.</a> by jpflori at 20121217T09:37:20</li></ol>
