### PR TITLE
Python 2.7.3.px spkg does not build on Cygwin.

### DIFF
--- a/build/pkgs/python/SPKG.txt
+++ b/build/pkgs/python/SPKG.txt
@@ -60,8 +60,17 @@ http://www.python.org/community/
  * sys_path_security.patch: ensure that the current working directory
    or the script directory is prepended to sys.path only if there is no
    security risk in doing so.
+ * io-issue_14437.patch: Fixes Python issue #14437 (building _io on Cygwin)
+ * ncurses-issue_9665.patch: Fixes Python issue #9665 (by patching configure
+   and configure.in after running autotools)
+ * ncurses-issue_14438.patch: Fixes Python issue #14438 (ncurses)
 
 == Changelog ==
+
+=== python-2.7.3.p3 (Jean-Pierre Flori, Karl-Dieter Crisman, 4 December 2012) ===
+ * Trac #13319: let Python build on Cygwin.
+ * Includes fixes from Python issues #9665, #14437, #14438.
+ * Jeroen's autotools was run in order to update the configure script.
 
 === python-2.7.3.p2 (Jeroen Demeyer, 29 October 2012) ===
  * Trac #13631: Keep in mind umask when checking security of "python -c"

--- a/build/pkgs/python/patches/Lib.distutils.command.sdist.patch
+++ b/build/pkgs/python/patches/Lib.distutils.command.sdist.patch
@@ -1,6 +1,6 @@
 --- src/Lib/distutils/command/sdist.py.orig	2011-05-20 15:24:44.936515549 +1200
 +++ src/Lib/distutils/command/sdist.py	2011-05-20 15:25:54.920519189 +1200
-@@ -324,7 +324,7 @@
+@@ -336,7 +336,7 @@
            * the build tree (typically "build")
            * the release tree itself (only an issue if we ran "sdist"
              previously with --keep-temp, or it aborted)
@@ -9,7 +9,7 @@
          """
          build = self.get_finalized_command('build')
          base_dir = self.distribution.get_fullname()
-@@ -339,7 +339,7 @@
+@@ -351,7 +351,7 @@
          else:
              seps = '/'
  

--- a/build/pkgs/python/patches/io-issue_14437.patch
+++ b/build/pkgs/python/patches/io-issue_14437.patch
@@ -1,0 +1,28 @@
+diff -ur src.orig/Misc/NEWS src/Misc/NEWS
+--- src.orig/Misc/NEWS	2012-08-01 10:51:33.927830611 +0200
++++ src/Misc/NEWS	2012-08-01 10:58:44.139814595 +0200
+@@ -12,6 +12,11 @@
+ - Issue #6884: Fix long-standing bugs with MANIFEST.in parsing in distutils
+   on Windows.
+ 
++Build
++-----
++
++- Issue #14437: Fix building the _io module under Cygwin.
++
+ 
+ What's New in Python 2.7.3 release candidate 2?
+ ===============================================
+Seulement dans src/Misc: NEWS.orig
+diff -ur src.orig/Modules/_io/_iomodule.h src/Modules/_io/_iomodule.h
+--- src.orig/Modules/_io/_iomodule.h	2012-08-01 10:51:36.487830516 +0200
++++ src/Modules/_io/_iomodule.h	2012-08-01 10:58:44.151814610 +0200
+@@ -72,7 +72,7 @@
+     PyObject *filename; /* Not used, but part of the IOError object */
+     Py_ssize_t written;
+ } PyBlockingIOErrorObject;
+-PyAPI_DATA(PyObject *) PyExc_BlockingIOError;
++extern PyObject *PyExc_BlockingIOError;
+ 
+ /*
+  * Offset type for positioning.

--- a/build/pkgs/python/patches/ncurses-issue_14438.patch
+++ b/build/pkgs/python/patches/ncurses-issue_14438.patch
@@ -1,0 +1,18 @@
+diff -ur src.orig/Include/py_curses.h src/Include/py_curses.h
+--- src.orig/Include/py_curses.h	2012-08-01 10:51:27.075830866 +0200
++++ src/Include/py_curses.h	2012-08-01 11:01:05.311809409 +0200
+@@ -17,6 +17,13 @@
+ #define NCURSES_OPAQUE 0
+ #endif /* __APPLE__ */
+ 
++#ifdef __CYGWIN__
++/* the following define is necessary for Cygwin; without it, the
++   Cygwin-supplied ncurses.h sets NCURSES_OPAQUE to 1, and then Python
++   can't get at the WINDOW flags field. */
++#define NCURSES_INTERNALS
++#endif /* __CYGWIN__ */
++
+ #ifdef __FreeBSD__
+ /*
+ ** On FreeBSD, [n]curses.h and stdlib.h/wchar.h use different guards
+Seulement dans src/Include: py_curses.h.orig

--- a/build/pkgs/python/patches/ncurses-issue_9665.patch
+++ b/build/pkgs/python/patches/ncurses-issue_9665.patch
@@ -1,0 +1,26 @@
+diff -ur src.orig/configure.in src/configure.in
+--- src.orig/configure.in	2012-09-30 19:16:16.208133911 +0200
++++ src/configure.in	2012-09-30 19:15:12.800599068 +0200
+@@ -1113,6 +1113,9 @@
+ 	OSF*)
+ 	    BASECFLAGS="$BASECFLAGS -mieee"
+ 	    ;;
++	CYGWIN*)
++	    BASECFLAGS="-I/usr/include/ncurses $BASECFLAGS"
++	    ;;
+     esac
+     ;;
+
+diff -ur src.orig/configure src/configure 
+--- src.orig/configure  2012-09-30 19:16:16.216133852 +0200 
++++ src/configure       2012-09-30 19:15:44.876363826 +0200 
+@@ -5613,6 +5613,9 @@
+ 	OSF*)
+ 	    BASECFLAGS="$BASECFLAGS -mieee"
+ 	    ;;
++	CYGWIN*)
++	    BASECFLAGS="-I/usr/include/ncurses $BASECFLAGS"
++	    ;;
+     esac
+     ;;
+ 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13319">trac #13319</a>.

spkg diff, for review only

Reported by: jpflori

Component: cygwin

CC: kcrisman,, dimpase

Report Upstream: Fixed upstream, but not in a stable release.

Authors: Jean-Pierre Flori

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/13579">trac #13579</a>

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.6.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13319/spkg.diff">spkg.diff: spkg diff, for review only</a> by jpflori at 20120930T17:29:42</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13319/python-2.7.3.p3-python-2.7.3.p2.diff">python-2.7.3.p3-python-2.7.3.p2.diff: Diff from #13631 to the kcrisman p3 spkg</a> by kcrisman at 20121204T19:12:49</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13319/python-2.7.3.p3.diff">python-2.7.3.p3.diff: spkg diff, for review only</a> by jpflori at 20121204T20:56:47</li></ol>
