### PR TITLE
Fix libsingular memory management

### DIFF
--- a/build/pkgs/singular/spkg-install
+++ b/build/pkgs/singular/spkg-install
@@ -95,7 +95,7 @@ apply_patches()
     fi
 
     if [ "x$SINGULAR_XALLOC" = "xyes" ]; then
-	rm -r $(SRC)/omalloc/*
+	rm -r ../src/omalloc/*
 	mv conditional/singular_xalloc.patch . || return $?
     fi
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13731">trac #13731</a>.

Patch added to the spkg

Reported by: nbruin

Component: memleak

CC: SimonKing,, fbissey,, malb

Report Upstream: Fixed upstream, in a later stable release.

Authors: Nils Bruin, Simon King

Dependencies: 

Work issues: 

Reviewers: Nils Bruin

Merged in: sage-5.6.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13731/sage_trac_13731.patch">sage_trac_13731.patch: A patch for the singular spkg to produce a libsingular that uses malloc</a> by SimonKing at 20121125T08:34:04</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13731/singular_15435.patch">singular_15435.patch: Backporting Singular changeset 15435</a> by SimonKing at 20121125T19:27:08</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13731/singular_part_of_changeset_baadc0f7.patch">singular_part_of_changeset_baadc0f7.patch: Backporting a small part of Singular changeset baadc0f7</a> by SimonKing at 20121129T21:23:06</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13731/singular_xalloc.patch">singular_xalloc.patch: Build Singular and libsingular with omalloc replaced by xalloc </a> by SimonKing at 20121130T14:25:49</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13731/xalloc-makefile.diff">xalloc-makefile.diff: Patch added to the spkg</a> by jdemeyer at 20121221T11:00:15</li></ol>
