### PR TITLE
New MPIR won't build on Cygwin

### DIFF
--- a/build/pkgs/mpir/SPKG.txt
+++ b/build/pkgs/mpir/SPKG.txt
@@ -54,6 +54,11 @@ See http://www.mpir.org
 
 == Changelog ==
 
+=== mpir-2.4.0.p7 (Karl-Dieter Crisman, Jean-Pierre Flori, 1 August 2012) ===
+ * Trac #12115: let MPIR build on Cygwin.
+ * Only build the shared version of the library on Cygwin.
+ * Export ABI=32 on Cygwin.
+
 === mpir-2.4.0.p6 (Jeroen Demeyer, 28 May 2012) ===
  * Trac #12751: Apply the ia64 workaround for gcc-4.7.0 *only* on
    gcc-4.7.0 and not on other gcc-4.7.x versions.

--- a/build/pkgs/mpir/spkg-install
+++ b/build/pkgs/mpir/spkg-install
@@ -178,7 +178,9 @@ case "$UNAME" in
         fi
         ;; # Linux
     CYGWIN)
-        # Nothing special performed (yet).
+        # For the moment, Cygwin is only 32-bits
+        # and configure gets lost if the hardware is 64 bits
+        ABI=32
         ;;
     *) # e.g. AIX or HP-UX
         echo >&2 "Warning: Your platform ($UNAME) isn't yet explicitly supported" \
@@ -219,9 +221,16 @@ if [ "$SAGE_BUILD_TOOLCHAIN" = yes ]; then
     MPIR_CONFIGURE="--disable-cxx --disable-static $MPIR_CONFIGURE"
     SAGE_FAT_BINARY=no
 else
-    # Also build the static library to be used by e.g. ECM:
-    echo "Building MPIR with the C++ interface and (also) static libraries."
-    MPIR_CONFIGURE="--enable-cxx --enable-static $MPIR_CONFIGURE"
+    # Also build the static library to be used by e.g. ECM
+    # unless we are on Cygwin where we can only build a shared
+    # or a static library but not both
+    if [ "$UNAME" = "CYGWIN" ]; then
+        echo "Building MPIR with the C++ interface."
+        MPIR_CONFIGURE="--enable-cxx --disable-static $MPIR_CONFIGURE"
+    else
+        echo "Building MPIR with the C++ interface and (also) static libraries."
+        MPIR_CONFIGURE="--enable-cxx --enable-static $MPIR_CONFIGURE"
+    fi
 fi
 # (Further options to 'configure' are added below.)
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12115">trac #12115</a>.

Spkg diff, for review only.

Reported by: kcrisman

Component: cygwin

CC: leif,, dimpase,, wbhart,, jdemeyer

Report Upstream: None of the above - read trac for reasoning.

Authors: 

Dependencies: 

Work issues: 

Reviewers: Volker Braun, Karl-Dieter Crisman, Jean-Pierre Flori

Merged in: 

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12115/draft-of-diff-mpir-2.1.3.p7-p8.diff">draft-of-diff-mpir-2.1.3.p7-p8.diff: For reference only - don't build static library</a> by kcrisman at 20111203T21:32:03</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12115/mpir-2.4.0.p5.log">mpir-2.4.0.p5.log: </a> by jpflori at 20120711T08:25:19</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12115/mpir-2.5.1.p1.log">mpir-2.5.1.p1.log: </a> by jpflori at 20120711T08:25:55</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12115/mpir-2.4.0.p6.log">mpir-2.4.0.p6.log: </a> by jpflori at 20120711T08:28:10</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12115/spkg.diff">spkg.diff: Spkg diff, for review only.</a> by jpflori at 20120801T12:56:04</li></ol>
