### PR TITLE
SEGFAULT in matrix_mod_pn for padic extensions

### DIFF
--- a/src/sage/rings/padics/padic_ZZ_pX_CR_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_CR_element.pyx
@@ -3258,14 +3258,16 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
 
     def matrix_mod_pn(self):
         """
-        Returns the matrix of right multiplication by the element on the power
-        basis `1, x, x^2, \ldots, x^{d-1}` for this extension field.  Thus the
-        *rows* of this matrix give the images of each of the `x^i`.  The
-        entries of the matrices are IntegerMod elements, defined modulo
-        ``p^(self.absprec() / e)`` (unless ``self`` is zero to arbitrary
-        precision; in that case the entries are integer zeros.)
+        Returns the matrix of right multiplication by the element on
+        the power basis `1, x, x^2, \ldots, x^{d-1}` for this
+        extension field.  Thus the *rows* of this matrix give the
+        images of each of the `x^i`.  The entries of the matrices are
+        IntegerMod elements, defined modulo `p^{N / e}` where `N` is
+        the absolute precision of this element (unless this element is
+        zero to arbitrary precision; in that case the entries are
+        integer zeros.)
 
-        Raises an error if ``self`` has negative valuation.
+        Raises an error if this element has negative valuation.
 
         EXAMPLES::
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13617">trac #13617</a>.

Reported by: saraedum

Component: padics

CC: 

Report Upstream: N/A

Authors: Julian Rueth

Dependencies: 

Work issues: 

Reviewers: David Roe, Punarbasu Purkayastha

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13617/trac_13617.patch">trac_13617.patch: </a> by saraedum at 20121025T02:11:31</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13617/13617_review.patch">13617_review.patch: </a> by roed at 20130318T19:10:45</li></ol>
