### PR TITLE
make absprec argument of p-adics lift_to_precision optional

### DIFF
--- a/src/sage/rings/padics/padic_ZZ_pX_CA_element.pxd
+++ b/src/sage/rings/padics/padic_ZZ_pX_CA_element.pxd
@@ -23,4 +23,4 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
     cpdef _ntl_rep_abs(self)
     cpdef ntl_ZZ_pX _ntl_rep(self)
 
-    cpdef pAdicZZpXCAElement lift_to_precision(self, absprec)
+    cpdef pAdicZZpXCAElement lift_to_precision(self, absprec=*)

--- a/src/sage/rings/padics/padic_ZZ_pX_CA_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_CA_element.pyx
@@ -1753,13 +1753,23 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
 
 #         raise NotImplementedError
 
-    cpdef pAdicZZpXCAElement lift_to_precision(self, absprec):
+    cpdef pAdicZZpXCAElement lift_to_precision(self, absprec=None):
         """
         Returns a ``pAdicZZpXCAElement`` congruent to ``self`` but with
-        absolute precision at least ``absprec``.  If setting ``absprec`` that
-        high would violate the precision cap, raises a precision error.
+        absolute precision at least ``absprec``.
 
-        Note that the new digits will not necessarily be zero.
+        INPUT:
+
+        - ``absprec`` -- (default ``None``) the absolute precision of
+          the result.  If ``None``, lifts to the maximum precision
+          allowed.
+
+        .. NOTE::
+
+            If setting ``absprec`` that high would violate the
+            precision cap, raises a precision error.
+
+            Note that the new digits will not necessarily be zero.
 
         EXAMPLES::
 
@@ -1779,18 +1789,24 @@ cdef class pAdicZZpXCAElement(pAdicZZpXElement):
             [345]
             sage: c._ntl_rep()
             [345]
+            sage: a.lift_to_precision().precision_absolute() == W.precision_cap()
+            True
         """
         cdef pAdicZZpXCAElement ans
         cdef long aprec, rprec
-        if not PY_TYPE_CHECK(absprec, Integer):
+        if absprec is not None and not PY_TYPE_CHECK(absprec, Integer):
             absprec = Integer(absprec)
-        if mpz_fits_slong_p((<Integer>absprec).value) == 0:
+        if absprec is None:
+            aprec = self.prime_pow.ram_prec_cap
+        elif mpz_fits_slong_p((<Integer>absprec).value) == 0:
             if mpz_sgn((<Integer>absprec).value) < 0:
                 return self
             else:
-                aprec = self.prime_pow.ram_prec_cap
+                raise PrecisionError("Precision higher than allowed by the precision cap.")
         else:
             aprec = mpz_get_si((<Integer>absprec).value)
+            if aprec > self.prime_pow.ram_prec_cap:
+                raise PrecisionError("Precision higher than allowed by the precision cap.")
         if aprec <= self.absprec:
             return self
         ans = self._new_c(aprec) # restores context

--- a/src/sage/rings/padics/padic_ZZ_pX_CR_element.pxd
+++ b/src/sage/rings/padics/padic_ZZ_pX_CR_element.pxd
@@ -31,4 +31,4 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
     cpdef _ntl_rep_abs(self)
     cpdef ntl_ZZ_pX _ntl_rep(self)
 
-    cpdef pAdicZZpXCRElement lift_to_precision(self, absprec)
+    cpdef pAdicZZpXCRElement lift_to_precision(self, absprec=*)

--- a/src/sage/rings/padics/padic_ZZ_pX_CR_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_CR_element.pyx
@@ -2538,15 +2538,25 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
 #        """
 #        raise NotImplementedError
 
-    cpdef pAdicZZpXCRElement lift_to_precision(self, absprec):
+    cpdef pAdicZZpXCRElement lift_to_precision(self, absprec=None):
         """
         Returns a ``pAdicZZpXCRElement`` congruent to ``self`` but with
-        absolute precision at least ``absprec``.  If setting ``absprec`` that
-        high would violate the precision cap, raises a precision
-        error.  If self is an inexact zero and ``absprec`` is greater than
-        the maximum allowed valuation, raises an error.
+        absolute precision at least ``absprec``.
 
-        Note that the new digits will not necessarily be zero.
+        INPUT:
+
+        - ``absprec`` -- (default ``None``) the absolute precision of
+          the result.  If ``None``, lifts to the maximum precision
+          allowed.
+
+        .. NOTE::
+
+            If setting ``absprec`` that high would violate the
+            precision cap, raises a precision error.  If self is an
+            inexact zero and ``absprec`` is greater than the maximum
+            allowed valuation, raises an error.
+
+            Note that the new digits will not necessarily be zero.
 
         EXAMPLES::
 
@@ -2566,32 +2576,40 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
             [19 35 118 60 121]
             sage: c._ntl_rep()
             [19 35 118 60 121]
+            sage: a.lift_to_precision().precision_relative() == W.precision_cap()
+            True
         """
         cdef pAdicZZpXCRElement ans
         cdef long aprec, rprec
         self._normalize()
         if self._is_exact_zero():
             return self
-        if not PY_TYPE_CHECK(absprec, Integer):
+        if absprec is not None and not PY_TYPE_CHECK(absprec, Integer):
             absprec = Integer(absprec)
-        if mpz_fits_slong_p((<Integer>absprec).value) == 0:
+        if absprec is None:
+            if self.relprec == 0:
+                # return an exact zero
+                ans = self._new_c(0)
+                ans._set_exact_zero()
+                return ans
+            aprec = self.prime_pow.ram_prec_cap + self.ordp
+        elif mpz_fits_slong_p((<Integer>absprec).value) == 0:
             if mpz_sgn((<Integer>absprec).value) < 0 or self.relprec == self.prime_pow.ram_prec_cap:
                 return self
             else:
                 if self.relprec == 0:
-                    raise ValueError, "absprec larger than maximum allowable valuation"
-                ans = self._new_c(self.prime_pow.ram_prec_cap)
-                ans.ordp = self.ordp
-                ZZ_pX_conv_modulus(ans.unit, self.unit, self.prime_pow.get_top_context().x)
-                return ans
-        aprec = mpz_get_si((<Integer>absprec).value)
+                    raise ValueError("absprec larger than maximum allowable valuation")
+                else:
+                    raise PrecisionError("Precision higher than allowed by the precision cap.")
+        else:
+            aprec = mpz_get_si((<Integer>absprec).value)
         if aprec <= self.ordp + self.relprec:
             return self
         if self.relprec == 0:
             if self.ordp >= aprec:
                 return self
             elif aprec >= maxordp:
-                raise ValueError, "absprec larger than maximum allowable valuation"
+                raise ValueError("absprec larger than maximum allowable valuation")
             else:
                 ans = self._new_c(0)
                 ans._set_inexact_zero(aprec)
@@ -2599,7 +2617,7 @@ cdef class pAdicZZpXCRElement(pAdicZZpXElement):
         # Now we're done handling all the special cases.
         rprec = aprec - self.ordp
         if rprec > self.prime_pow.ram_prec_cap:
-            raise PrecisionError, "Precision higher than allowed by the precision cap."
+            raise PrecisionError("Precision higher than allowed by the precision cap.")
         ans = self._new_c(rprec)
         ans.ordp = self.ordp
         ZZ_pX_conv_modulus(ans.unit, self.unit, self.prime_pow.get_context_capdiv(rprec).x)

--- a/src/sage/rings/padics/padic_ZZ_pX_FM_element.pyx
+++ b/src/sage/rings/padics/padic_ZZ_pX_FM_element.pyx
@@ -1546,7 +1546,7 @@ cdef class pAdicZZpXFMElement(pAdicZZpXElement):
 #        """
 #        raise NotImplementedError
 
-    def lift_to_precision(self, absprec):
+    def lift_to_precision(self, absprec=None):
         """
         Returns ``self``.
 

--- a/src/sage/rings/padics/padic_fixed_mod_element.pyx
+++ b/src/sage/rings/padics/padic_fixed_mod_element.pyx
@@ -821,7 +821,7 @@ cdef class pAdicFixedModElement(pAdicBaseGenericElement):
         mpz_set(ans.value, self.value)
         return ans
 
-    def lift_to_precision(self, absprec):
+    def lift_to_precision(self, absprec=None):
         """
         Returns self.
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14294">trac #14294</a>.

Reported by: roed

Component: padics

CC: 

Report Upstream: N/A

Authors: David Roe

Dependencies: 

Work issues: 

Reviewers: Julian Rueth

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14294/14294.patch">14294.patch: </a> by roed at 20130318T10:08:54</li></ol>
