### PR TITLE
The new doctesting framework doesn't like being run with nohup

### DIFF
--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -1651,7 +1651,15 @@ class DocTestWorker(multiprocessing.Process):
         # Ensure the Python stdin is the actual stdin
         # (multiprocessing redirects this).
         # We will do a more proper redirect of stdin in SageSpoofInOut.
-        sys.stdin = os.fdopen(0, "r")
+        try:
+            sys.stdin = os.fdopen(0, "r")
+        except OSError:
+            # We failed to open stdin for reading, this might happen
+            # for example when running under "nohup" (Trac #14307).
+            # Simply redirect stdin from /dev/null and try again.
+            with open(os.devnull) as f:
+                os.dup2(f.fileno(), 0)
+            sys.stdin = os.fdopen(0, "r")
 
         # Close the reading end of the pipe (only the master should
         # read from the pipe) and open the writing end.


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14307">trac #14307</a>.

Reported by: fbissey

Component: doctest

CC: jdemeyer

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12415">trac #12415</a>

Work issues: 

Reviewers: François Bissey

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14307/14307_bad_stdin.patch">14307_bad_stdin.patch: </a> by jdemeyer at 20130319T10:14:02</li></ol>
