### PR TITLE
Fix slice and __getitem__ methods of padics

### DIFF
--- a/src/sage/rings/padics/local_generic_element.pyx
+++ b/src/sage/rings/padics/local_generic_element.pyx
@@ -208,13 +208,6 @@ cdef class LocalGenericElement(CommutativeRingElement):
 
         - ``k`` -- (default: 1) a positive integer
 
-        .. WARNING::
-
-            In Python if you create a slice as ``a[:5]``, the start
-            attribute will be set to 0 rather than None.  As a
-            consequence, ``a[:5]`` will start the slice at 0 whereas
-            ``a.slice(None, 5)`` will start at the valution.
-
         EXAMPLES::
 
             sage: R = Zp(5, 6, 'capped-rel')
@@ -263,7 +256,7 @@ cdef class LocalGenericElement(CommutativeRingElement):
             sage: x.slice(None, 3)
             5^-2 + 5 + O(5^3)
             sage: x[:3]
-            5 + O(5^3)
+            5^-2 + 5 + O(5^3)
 
         TESTS:
 
@@ -343,8 +336,8 @@ cdef class LocalGenericElement(CommutativeRingElement):
             ppow *= pk
 
         # fix the precision of the return value
-        if j < self.precision_absolute():
-            ans = self.add_bigoh(j)
+        if j < ans.precision_absolute() or self.precision_absolute() < ans.precision_absolute():
+            ans = ans.add_bigoh(min(j,self.precision_absolute()))
 
         return ans
 

--- a/src/sage/rings/padics/padic_generic_element.pyx
+++ b/src/sage/rings/padics/padic_generic_element.pyx
@@ -271,14 +271,6 @@ cdef class pAdicGenericElement(LocalGenericElement):
         Returns the coefficient of `p^n` in the series expansion of this
         element, as an integer in the range `0` to `p-1`.
 
-        .. WARNING::
-
-            In Python if you create a slice as ``a[:5]``, the start
-            attribute will be set to 0 rather than None.  As a
-            consequence, this function behaves differently than
-            ``a.slice(None, 5)`` on such inputs: this function starts
-            at 0 while slice starts at the valution.
-
         EXAMPLES::
 
             sage: R = Zp(7,4,'capped-rel','series'); a = R(1/3); a
@@ -335,17 +327,6 @@ cdef class pAdicGenericElement(LocalGenericElement):
             4*7^3 + O(7^4)
             sage: b[3:7]
             O(7^3)
-
-        Note that if the first entry in the slice is blank it will be
-        set to zero::
-
-            sage: K = Qp(5, 6)
-            sage: x = K(1/25 + 5); x
-            5^-2 + 5 + O(5^4)
-            sage: x[:3]
-            5 + O(5^3)
-            sage: x.slice(None, 3)
-            5^-2 + 5 + O(5^3)
 
         For extension elements, "zeros" match the behavior of
         ``list``::


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13299">trac #13299</a>.

fixed new-style slices

Reported by: saraedum

Component: padics

CC: roed

Report Upstream: N/A

Authors: Julian Rueth

Dependencies: 

Work issues: 

Reviewers: Rob Harron, David Roe

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13299/trac_13299.patch">trac_13299.patch: </a> by saraedum at 20130213T16:58:29</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13299/13299_review.patch">13299_review.patch: </a> by roed at 20130316T19:41:49</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13299/trac_13299_review2.patch">trac_13299_review2.patch: fixed new-style slices</a> by saraedum at 20130318T06:16:42</li></ol>
