### PR TITLE
LyndonWords from composition beginning by 0's

### DIFF
--- a/src/sage/combinat/lyndon_word.py
+++ b/src/sage/combinat/lyndon_word.py
@@ -88,14 +88,14 @@ def LyndonWords(e=None, k=None):
     elif isinstance(e, (int, Integer)):
         if e > 0:
             if not isinstance(k, (int, Integer)):
-                raise TypeError, "k must be a non-negative integer"
+                raise TypeError("k must be a non-negative integer")
             if k < 0:
-                raise TypeError, "k must be a non-negative integer"
+                raise TypeError("k must be a non-negative integer")
             return LyndonWords_nk(e, k)
     elif e in Compositions():
         return LyndonWords_evaluation(e)
 
-    raise TypeError, "e must be a positive integer or a composition"
+    raise TypeError("e must be a positive integer or a composition")
 
 class LyndonWord(FiniteWord_list):
     def __init__(self, data, check=True):
@@ -130,7 +130,7 @@ class LyndonWord(FiniteWord_list):
         """
         super(LyndonWord,self).__init__(parent=LyndonWords(),data=data)
         if check and not self.is_lyndon():
-            raise ValueError, "Not a Lyndon word"
+            raise ValueError("Not a Lyndon word")
 
 class LyndonWords_class(Words_all):
     def __repr__(self):


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12997">trac #12997</a>.

Reported by: Adrien

Component: combinatorics

CC: slabbe,, saliola

Report Upstream: N/A

Authors: Adrien Brochier

Dependencies: 

Work issues: 

Reviewers: Travis Scrimshaw, Frédéric Chapoton

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12997/lyndon_word.py">lyndon_word.py: Modified lyndon_word.py</a> by Adrien at 20120524T11:21:54</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12997/diff">diff: diff</a> by Adrien at 20120524T11:22:07</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12997/trac_12997-LyndonWords-compositions.patch">trac_12997-LyndonWords-compositions.patch: patch</a> by Adrien at 20120530T10:57:35</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12997/trac_12997-LyndonWords-review-ts.patch">trac_12997-LyndonWords-review-ts.patch: </a> by tscrim at 20130216T02:26:45</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12997/trac_12997-Lyndon-review-fc.patch">trac_12997-Lyndon-review-fc.patch: </a> by chapoton at 20130317T20:07:52</li></ol>
