### PR TITLE
Upgrade MPC to version 1.0

### DIFF
--- a/build/pkgs/mpc/SPKG.txt
+++ b/build/pkgs/mpc/SPKG.txt
@@ -33,9 +33,15 @@ The MPC team can be contact via the MPC mailing list:
 
 == Special Update/Build Instructions ==
 
-None.
+Patches:
+ * configure.patch: move AM_PROG_AR after MPC_GMP_CC_CFLAGS, see
+   https://gforge.inria.fr/tracker/?func=detail&group_id=131&aid=14669&atid=607
+   (patch scheduled to be merged upstream in mpc-1.0.1)
 
 == Changelog ==
+
+=== mpc-1.0.p0 (Jeroen Demeyer, 1 August 2012) ===
+ * Trac #13290: add configure.patch (see above).
 
 === mpc-1.0 (Jeroen Demeyer, 27 July 2012) ===
  * Trac #13290: upgrade to stable version 1.0.

--- a/build/pkgs/mpc/patches/configure.patch
+++ b/build/pkgs/mpc/patches/configure.patch
@@ -1,0 +1,1842 @@
+diff -rud src/configure.ac b/configure.ac
+--- src/configure.ac	2012-07-19 14:33:51.000000000 +0200
++++ b/configure.ac	2012-08-01 15:34:32.000000000 +0200
+@@ -30,9 +30,6 @@
+ USER_CC=$CC
+ USER_CFLAGS=$CFLAGS
+ 
+-# automake 1.12 seems to require this, but automake 1.11 doesn't recognize it
+-m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+-
+ AC_CANONICAL_HOST
+ AC_CONFIG_MACRO_DIR([m4])
+ 
+@@ -111,6 +108,11 @@
+ AC_PROG_CC
+ AC_LANG(C)
+ 
++# Automake 1.12 seems to require this, but automake 1.11 doesn't recognize it.
++# Do not call AM_PROG_AR before MPC_GMP_CC_CFLAGS, since otherwise ac_cv_prog_CC
++# is already set and overrides our CC setting (which may come from gmp.h).
++m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
++
+ # Set up LibTool
+ LT_INIT
+ 
+diff -rud src/aclocal.m4 b/aclocal.m4
+--- src/aclocal.m4	2012-07-19 14:33:57.000000000 +0200
++++ b/aclocal.m4	2012-08-01 15:56:44.000000000 +0200
+@@ -1,4 +1,4 @@
+-# generated automatically by aclocal 1.11.5 -*- Autoconf -*-
++# generated automatically by aclocal 1.11.6 -*- Autoconf -*-
+ 
+ # Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
+ # 2005, 2006, 2007, 2008, 2009, 2010, 2011 Free Software Foundation,
+@@ -38,7 +38,7 @@
+ [am__api_version='1.11'
+ dnl Some users find AM_AUTOMAKE_VERSION and mistake it for a way to
+ dnl require some minimum version.  Point them to the right macro.
+-m4_if([$1], [1.11.5], [],
++m4_if([$1], [1.11.6], [],
+       [AC_FATAL([Do not call $0, use AM_INIT_AUTOMAKE([$1]).])])dnl
+ ])
+ 
+@@ -54,7 +54,7 @@
+ # Call AM_AUTOMAKE_VERSION and AM_AUTOMAKE_VERSION so they can be traced.
+ # This function is AC_REQUIREd by AM_INIT_AUTOMAKE.
+ AC_DEFUN([AM_SET_CURRENT_AUTOMAKE_VERSION],
+-[AM_AUTOMAKE_VERSION([1.11.5])dnl
++[AM_AUTOMAKE_VERSION([1.11.6])dnl
+ m4_ifndef([AC_AUTOCONF_VERSION],
+   [m4_copy([m4_PACKAGE_VERSION], [AC_AUTOCONF_VERSION])])dnl
+ _AM_AUTOCONF_VERSION(m4_defn([AC_AUTOCONF_VERSION]))])
+Only in b: autom4te.cache
+diff -rud src/configure b/configure
+--- src/configure	2012-07-19 14:33:58.000000000 +0200
++++ b/configure	2012-08-01 15:56:46.000000000 +0200
+@@ -659,18 +659,8 @@
+ LD
+ FGREP
+ LIBTOOL
+-SED
+-EGREP
+-GREP
+-VALGRIND
+-host_os
+-host_vendor
+-host_cpu
+-host
+-build_os
+-build_vendor
+-build_cpu
+-build
++ac_ct_AR
++AR
+ am__fastdepCC_FALSE
+ am__fastdepCC_TRUE
+ CCDEPMODE
+@@ -688,8 +678,18 @@
+ LDFLAGS
+ CFLAGS
+ CC
+-ac_ct_AR
+-AR
++SED
++EGREP
++GREP
++VALGRIND
++host_os
++host_vendor
++host_cpu
++host
++build_os
++build_vendor
++build_cpu
++build
+ MAINT
+ MAINTAINER_MODE_FALSE
+ MAINTAINER_MODE_TRUE
+@@ -758,7 +758,6 @@
+ ac_user_opts='
+ enable_option_checking
+ enable_maintainer_mode
+-enable_dependency_tracking
+ with_mpfr_include
+ with_mpfr_lib
+ with_mpfr
+@@ -767,6 +766,7 @@
+ with_gmp
+ enable_logging
+ enable_valgrind_tests
++enable_dependency_tracking
+ enable_shared
+ enable_static
+ with_pic
+@@ -1404,11 +1404,11 @@
+   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+   --enable-maintainer-mode  enable make rules and dependencies not useful
+ 			  (and sometimes confusing) to the casual installer
+-  --disable-dependency-tracking  speeds up one-time build
+-  --enable-dependency-tracking   do not reject slow dependency extractors
+   --enable-logging        enable logging of function calls to stderr (default
+                           = no)
+   --enable-valgrind-tests run checks through valgrind (default = no)
++  --disable-dependency-tracking  speeds up one-time build
++  --enable-dependency-tracking   do not reject slow dependency extractors
+   --enable-shared[=PKGS]  build shared libraries [default=yes]
+   --enable-static[=PKGS]  build static libraries [default=yes]
+   --enable-fast-install[=PKGS]
+@@ -2815,1149 +2815,6 @@
+ USER_CC=$CC
+ USER_CFLAGS=$CFLAGS
+ 
+-# automake 1.12 seems to require this, but automake 1.11 doesn't recognize it
+-DEPDIR="${am__leading_dot}deps"
+-
+-ac_config_commands="$ac_config_commands depfiles"
+-
+-
+-am_make=${MAKE-make}
+-cat > confinc << 'END'
+-am__doit:
+-	@echo this is the am__doit target
+-.PHONY: am__doit
+-END
+-# If we don't find an include directive, just comment out the code.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for style of include used by $am_make" >&5
+-$as_echo_n "checking for style of include used by $am_make... " >&6; }
+-am__include="#"
+-am__quote=
+-_am_result=none
+-# First try GNU make style include.
+-echo "include confinc" > confmf
+-# Ignore all kinds of additional output from `make'.
+-case `$am_make -s -f confmf 2> /dev/null` in #(
+-*the\ am__doit\ target*)
+-  am__include=include
+-  am__quote=
+-  _am_result=GNU
+-  ;;
+-esac
+-# Now try BSD make style include.
+-if test "$am__include" = "#"; then
+-   echo '.include "confinc"' > confmf
+-   case `$am_make -s -f confmf 2> /dev/null` in #(
+-   *the\ am__doit\ target*)
+-     am__include=.include
+-     am__quote="\""
+-     _am_result=BSD
+-     ;;
+-   esac
+-fi
+-
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $_am_result" >&5
+-$as_echo "$_am_result" >&6; }
+-rm -f confinc confmf
+-
+-# Check whether --enable-dependency-tracking was given.
+-if test "${enable_dependency_tracking+set}" = set; then :
+-  enableval=$enable_dependency_tracking;
+-fi
+-
+-if test "x$enable_dependency_tracking" != xno; then
+-  am_depcomp="$ac_aux_dir/depcomp"
+-  AMDEPBACKSLASH='\'
+-  am__nodep='_no'
+-fi
+- if test "x$enable_dependency_tracking" != xno; then
+-  AMDEP_TRUE=
+-  AMDEP_FALSE='#'
+-else
+-  AMDEP_TRUE='#'
+-  AMDEP_FALSE=
+-fi
+-
+-
+-ac_ext=c
+-ac_cpp='$CPP $CPPFLAGS'
+-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_c_compiler_gnu
+-if test -n "$ac_tool_prefix"; then
+-  # Extract the first word of "${ac_tool_prefix}gcc", so it can be a program name with args.
+-set dummy ${ac_tool_prefix}gcc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$CC"; then
+-  ac_cv_prog_CC="$CC" # Let the user override the test.
+-else
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_CC="${ac_tool_prefix}gcc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-fi
+-fi
+-CC=$ac_cv_prog_CC
+-if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-fi
+-if test -z "$ac_cv_prog_CC"; then
+-  ac_ct_CC=$CC
+-  # Extract the first word of "gcc", so it can be a program name with args.
+-set dummy gcc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_ac_ct_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$ac_ct_CC"; then
+-  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
+-else
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_ac_ct_CC="gcc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-fi
+-fi
+-ac_ct_CC=$ac_cv_prog_ac_ct_CC
+-if test -n "$ac_ct_CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+-$as_echo "$ac_ct_CC" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-  if test "x$ac_ct_CC" = x; then
+-    CC=""
+-  else
+-    case $cross_compiling:$ac_tool_warned in
+-yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+-ac_tool_warned=yes ;;
+-esac
+-    CC=$ac_ct_CC
+-  fi
+-else
+-  CC="$ac_cv_prog_CC"
+-fi
+-
+-if test -z "$CC"; then
+-          if test -n "$ac_tool_prefix"; then
+-    # Extract the first word of "${ac_tool_prefix}cc", so it can be a program name with args.
+-set dummy ${ac_tool_prefix}cc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$CC"; then
+-  ac_cv_prog_CC="$CC" # Let the user override the test.
+-else
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_CC="${ac_tool_prefix}cc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-fi
+-fi
+-CC=$ac_cv_prog_CC
+-if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-  fi
+-fi
+-if test -z "$CC"; then
+-  # Extract the first word of "cc", so it can be a program name with args.
+-set dummy cc; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$CC"; then
+-  ac_cv_prog_CC="$CC" # Let the user override the test.
+-else
+-  ac_prog_rejected=no
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    if test "$as_dir/$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
+-       ac_prog_rejected=yes
+-       continue
+-     fi
+-    ac_cv_prog_CC="cc"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-if test $ac_prog_rejected = yes; then
+-  # We found a bogon in the path, so make sure we never use it.
+-  set dummy $ac_cv_prog_CC
+-  shift
+-  if test $# != 0; then
+-    # We chose a different compiler from the bogus one.
+-    # However, it has the same basename, so the bogon will be chosen
+-    # first if we set CC to just the basename; use the full file name.
+-    shift
+-    ac_cv_prog_CC="$as_dir/$ac_word${1+' '}$@"
+-  fi
+-fi
+-fi
+-fi
+-CC=$ac_cv_prog_CC
+-if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-fi
+-if test -z "$CC"; then
+-  if test -n "$ac_tool_prefix"; then
+-  for ac_prog in cl.exe
+-  do
+-    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+-set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$CC"; then
+-  ac_cv_prog_CC="$CC" # Let the user override the test.
+-else
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_CC="$ac_tool_prefix$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-fi
+-fi
+-CC=$ac_cv_prog_CC
+-if test -n "$CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+-$as_echo "$CC" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-    test -n "$CC" && break
+-  done
+-fi
+-if test -z "$CC"; then
+-  ac_ct_CC=$CC
+-  for ac_prog in cl.exe
+-do
+-  # Extract the first word of "$ac_prog", so it can be a program name with args.
+-set dummy $ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_ac_ct_CC+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$ac_ct_CC"; then
+-  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
+-else
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_ac_ct_CC="$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-fi
+-fi
+-ac_ct_CC=$ac_cv_prog_ac_ct_CC
+-if test -n "$ac_ct_CC"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+-$as_echo "$ac_ct_CC" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-  test -n "$ac_ct_CC" && break
+-done
+-
+-  if test "x$ac_ct_CC" = x; then
+-    CC=""
+-  else
+-    case $cross_compiling:$ac_tool_warned in
+-yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+-ac_tool_warned=yes ;;
+-esac
+-    CC=$ac_ct_CC
+-  fi
+-fi
+-
+-fi
+-
+-
+-test -z "$CC" && { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "no acceptable C compiler found in \$PATH
+-See \`config.log' for more details" "$LINENO" 5; }
+-
+-# Provide some information about the compiler.
+-$as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
+-set X $ac_compile
+-ac_compiler=$2
+-for ac_option in --version -v -V -qversion; do
+-  { { ac_try="$ac_compiler $ac_option >&5"
+-case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_compiler $ac_option >&5") 2>conftest.err
+-  ac_status=$?
+-  if test -s conftest.err; then
+-    sed '10a\
+-... rest of stderr output deleted ...
+-         10q' conftest.err >conftest.er1
+-    cat conftest.er1 >&5
+-  fi
+-  rm -f conftest.er1 conftest.err
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }
+-done
+-
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-ac_clean_files_save=$ac_clean_files
+-ac_clean_files="$ac_clean_files a.out a.out.dSYM a.exe b.out"
+-# Try to create an executable without -o first, disregard a.out.
+-# It will help us diagnose broken compilers, and finding out an intuition
+-# of exeext.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
+-$as_echo_n "checking whether the C compiler works... " >&6; }
+-ac_link_default=`$as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
+-
+-# The possible output files:
+-ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
+-
+-ac_rmfiles=
+-for ac_file in $ac_files
+-do
+-  case $ac_file in
+-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
+-    * ) ac_rmfiles="$ac_rmfiles $ac_file";;
+-  esac
+-done
+-rm -f $ac_rmfiles
+-
+-if { { ac_try="$ac_link_default"
+-case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_link_default") 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
+-  # Autoconf-2.13 could set the ac_cv_exeext variable to `no'.
+-# So ignore a value of `no', otherwise this would lead to `EXEEXT = no'
+-# in a Makefile.  We should not override ac_cv_exeext if it was cached,
+-# so that the user can short-circuit this test for compilers unknown to
+-# Autoconf.
+-for ac_file in $ac_files ''
+-do
+-  test -f "$ac_file" || continue
+-  case $ac_file in
+-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj )
+-	;;
+-    [ab].out )
+-	# We found the default executable, but exeext='' is most
+-	# certainly right.
+-	break;;
+-    *.* )
+-	if test "${ac_cv_exeext+set}" = set && test "$ac_cv_exeext" != no;
+-	then :; else
+-	   ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
+-	fi
+-	# We set ac_cv_exeext here because the later test for it is not
+-	# safe: cross compilers may not add the suffix if given an `-o'
+-	# argument, so we may need to know it at that point already.
+-	# Even if this section looks crufty: it has the advantage of
+-	# actually working.
+-	break;;
+-    * )
+-	break;;
+-  esac
+-done
+-test "$ac_cv_exeext" = no && ac_cv_exeext=
+-
+-else
+-  ac_file=''
+-fi
+-if test -z "$ac_file"; then :
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-$as_echo "$as_me: failed program was:" >&5
+-sed 's/^/| /' conftest.$ac_ext >&5
+-
+-{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error 77 "C compiler cannot create executables
+-See \`config.log' for more details" "$LINENO" 5; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+-$as_echo "yes" >&6; }
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
+-$as_echo_n "checking for C compiler default output file name... " >&6; }
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
+-$as_echo "$ac_file" >&6; }
+-ac_exeext=$ac_cv_exeext
+-
+-rm -f -r a.out a.out.dSYM a.exe conftest$ac_cv_exeext b.out
+-ac_clean_files=$ac_clean_files_save
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
+-$as_echo_n "checking for suffix of executables... " >&6; }
+-if { { ac_try="$ac_link"
+-case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_link") 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
+-  # If both `conftest.exe' and `conftest' are `present' (well, observable)
+-# catch `conftest.exe'.  For instance with Cygwin, `ls conftest' will
+-# work properly (i.e., refer to `conftest.exe'), while it won't with
+-# `rm'.
+-for ac_file in conftest.exe conftest conftest.*; do
+-  test -f "$ac_file" || continue
+-  case $ac_file in
+-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
+-    *.* ) ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
+-	  break;;
+-    * ) break;;
+-  esac
+-done
+-else
+-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot compute suffix of executables: cannot compile and link
+-See \`config.log' for more details" "$LINENO" 5; }
+-fi
+-rm -f conftest conftest$ac_cv_exeext
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
+-$as_echo "$ac_cv_exeext" >&6; }
+-
+-rm -f conftest.$ac_ext
+-EXEEXT=$ac_cv_exeext
+-ac_exeext=$EXEEXT
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <stdio.h>
+-int
+-main ()
+-{
+-FILE *f = fopen ("conftest.out", "w");
+- return ferror (f) || fclose (f) != 0;
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-ac_clean_files="$ac_clean_files conftest.out"
+-# Check that the compiler produces executables we can run.  If not, either
+-# the compiler is broken, or we cross compile.
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
+-$as_echo_n "checking whether we are cross compiling... " >&6; }
+-if test "$cross_compiling" != yes; then
+-  { { ac_try="$ac_link"
+-case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_link") 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }
+-  if { ac_try='./conftest$ac_cv_exeext'
+-  { { case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_try") 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; }; then
+-    cross_compiling=no
+-  else
+-    if test "$cross_compiling" = maybe; then
+-	cross_compiling=yes
+-    else
+-	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot run C compiled programs.
+-If you meant to cross compile, use \`--host'.
+-See \`config.log' for more details" "$LINENO" 5; }
+-    fi
+-  fi
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
+-$as_echo "$cross_compiling" >&6; }
+-
+-rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out
+-ac_clean_files=$ac_clean_files_save
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
+-$as_echo_n "checking for suffix of object files... " >&6; }
+-if ${ac_cv_objext+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-rm -f conftest.o conftest.obj
+-if { { ac_try="$ac_compile"
+-case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_compile") 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }; then :
+-  for ac_file in conftest.o conftest.obj conftest.*; do
+-  test -f "$ac_file" || continue;
+-  case $ac_file in
+-    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM ) ;;
+-    *) ac_cv_objext=`expr "$ac_file" : '.*\.\(.*\)'`
+-       break;;
+-  esac
+-done
+-else
+-  $as_echo "$as_me: failed program was:" >&5
+-sed 's/^/| /' conftest.$ac_ext >&5
+-
+-{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+-as_fn_error $? "cannot compute suffix of object files: cannot compile
+-See \`config.log' for more details" "$LINENO" 5; }
+-fi
+-rm -f conftest.$ac_cv_objext conftest.$ac_ext
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
+-$as_echo "$ac_cv_objext" >&6; }
+-OBJEXT=$ac_cv_objext
+-ac_objext=$OBJEXT
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C compiler" >&5
+-$as_echo_n "checking whether we are using the GNU C compiler... " >&6; }
+-if ${ac_cv_c_compiler_gnu+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-#ifndef __GNUC__
+-       choke me
+-#endif
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-  ac_compiler_gnu=yes
+-else
+-  ac_compiler_gnu=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-ac_cv_c_compiler_gnu=$ac_compiler_gnu
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
+-$as_echo "$ac_cv_c_compiler_gnu" >&6; }
+-if test $ac_compiler_gnu = yes; then
+-  GCC=yes
+-else
+-  GCC=
+-fi
+-ac_test_CFLAGS=${CFLAGS+set}
+-ac_save_CFLAGS=$CFLAGS
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
+-$as_echo_n "checking whether $CC accepts -g... " >&6; }
+-if ${ac_cv_prog_cc_g+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_save_c_werror_flag=$ac_c_werror_flag
+-   ac_c_werror_flag=yes
+-   ac_cv_prog_cc_g=no
+-   CFLAGS="-g"
+-   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-  ac_cv_prog_cc_g=yes
+-else
+-  CFLAGS=""
+-      cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-
+-else
+-  ac_c_werror_flag=$ac_save_c_werror_flag
+-	 CFLAGS="-g"
+-	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-  ac_cv_prog_cc_g=yes
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-   ac_c_werror_flag=$ac_save_c_werror_flag
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
+-$as_echo "$ac_cv_prog_cc_g" >&6; }
+-if test "$ac_test_CFLAGS" = set; then
+-  CFLAGS=$ac_save_CFLAGS
+-elif test $ac_cv_prog_cc_g = yes; then
+-  if test "$GCC" = yes; then
+-    CFLAGS="-g -O2"
+-  else
+-    CFLAGS="-g"
+-  fi
+-else
+-  if test "$GCC" = yes; then
+-    CFLAGS="-O2"
+-  else
+-    CFLAGS=
+-  fi
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CC option to accept ISO C89" >&5
+-$as_echo_n "checking for $CC option to accept ISO C89... " >&6; }
+-if ${ac_cv_prog_cc_c89+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  ac_cv_prog_cc_c89=no
+-ac_save_CC=$CC
+-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-#include <stdarg.h>
+-#include <stdio.h>
+-struct stat;
+-/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
+-struct buf { int x; };
+-FILE * (*rcsopen) (struct buf *, struct stat *, int);
+-static char *e (p, i)
+-     char **p;
+-     int i;
+-{
+-  return p[i];
+-}
+-static char *f (char * (*g) (char **, int), char **p, ...)
+-{
+-  char *s;
+-  va_list v;
+-  va_start (v,p);
+-  s = g (p, va_arg (v,int));
+-  va_end (v);
+-  return s;
+-}
+-
+-/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
+-   function prototypes and stuff, but not '\xHH' hex character constants.
+-   These don't provoke an error unfortunately, instead are silently treated
+-   as 'x'.  The following induces an error, until -std is added to get
+-   proper ANSI mode.  Curiously '\x00'!='x' always comes out true, for an
+-   array size at least.  It's necessary to write '\x00'==0 to get something
+-   that's true only with -std.  */
+-int osf4_cc_array ['\x00' == 0 ? 1 : -1];
+-
+-/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
+-   inside strings and character constants.  */
+-#define FOO(x) 'x'
+-int xlc6_cc_array[FOO(a) == 'x' ? 1 : -1];
+-
+-int test (int i, double x);
+-struct s1 {int (*f) (int a);};
+-struct s2 {int (*f) (double a);};
+-int pairnames (int, char **, FILE *(*)(struct buf *, struct stat *, int), int, int);
+-int argc;
+-char **argv;
+-int
+-main ()
+-{
+-return f (e, argv, 0) != argv[0]  ||  f (e, argv, 1) != argv[1];
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std \
+-	-Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
+-do
+-  CC="$ac_save_CC $ac_arg"
+-  if ac_fn_c_try_compile "$LINENO"; then :
+-  ac_cv_prog_cc_c89=$ac_arg
+-fi
+-rm -f core conftest.err conftest.$ac_objext
+-  test "x$ac_cv_prog_cc_c89" != "xno" && break
+-done
+-rm -f conftest.$ac_ext
+-CC=$ac_save_CC
+-
+-fi
+-# AC_CACHE_VAL
+-case "x$ac_cv_prog_cc_c89" in
+-  x)
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+-$as_echo "none needed" >&6; } ;;
+-  xno)
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+-$as_echo "unsupported" >&6; } ;;
+-  *)
+-    CC="$CC $ac_cv_prog_cc_c89"
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
+-$as_echo "$ac_cv_prog_cc_c89" >&6; } ;;
+-esac
+-if test "x$ac_cv_prog_cc_c89" != xno; then :
+-
+-fi
+-
+-ac_ext=c
+-ac_cpp='$CPP $CPPFLAGS'
+-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_c_compiler_gnu
+-
+-depcc="$CC"   am_compiler_list=
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking dependency style of $depcc" >&5
+-$as_echo_n "checking dependency style of $depcc... " >&6; }
+-if ${am_cv_CC_dependencies_compiler_type+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -z "$AMDEP_TRUE" && test -f "$am_depcomp"; then
+-  # We make a subdir and do the tests there.  Otherwise we can end up
+-  # making bogus files that we don't know about and never remove.  For
+-  # instance it was reported that on HP-UX the gcc test will end up
+-  # making a dummy file named `D' -- because `-MD' means `put the output
+-  # in D'.
+-  rm -rf conftest.dir
+-  mkdir conftest.dir
+-  # Copy depcomp to subdir because otherwise we won't find it if we're
+-  # using a relative directory.
+-  cp "$am_depcomp" conftest.dir
+-  cd conftest.dir
+-  # We will build objects and dependencies in a subdirectory because
+-  # it helps to detect inapplicable dependency modes.  For instance
+-  # both Tru64's cc and ICC support -MD to output dependencies as a
+-  # side effect of compilation, but ICC will put the dependencies in
+-  # the current directory while Tru64 will put them in the object
+-  # directory.
+-  mkdir sub
+-
+-  am_cv_CC_dependencies_compiler_type=none
+-  if test "$am_compiler_list" = ""; then
+-     am_compiler_list=`sed -n 's/^#*\([a-zA-Z0-9]*\))$/\1/p' < ./depcomp`
+-  fi
+-  am__universal=false
+-  case " $depcc " in #(
+-     *\ -arch\ *\ -arch\ *) am__universal=true ;;
+-     esac
+-
+-  for depmode in $am_compiler_list; do
+-    # Setup a source with many dependencies, because some compilers
+-    # like to wrap large dependency lists on column 80 (with \), and
+-    # we should not choose a depcomp mode which is confused by this.
+-    #
+-    # We need to recreate these files for each test, as the compiler may
+-    # overwrite some of them when testing with obscure command lines.
+-    # This happens at least with the AIX C compiler.
+-    : > sub/conftest.c
+-    for i in 1 2 3 4 5 6; do
+-      echo '#include "conftst'$i'.h"' >> sub/conftest.c
+-      # Using `: > sub/conftst$i.h' creates only sub/conftst1.h with
+-      # Solaris 8's {/usr,}/bin/sh.
+-      touch sub/conftst$i.h
+-    done
+-    echo "${am__include} ${am__quote}sub/conftest.Po${am__quote}" > confmf
+-
+-    # We check with `-c' and `-o' for the sake of the "dashmstdout"
+-    # mode.  It turns out that the SunPro C++ compiler does not properly
+-    # handle `-M -o', and we need to detect this.  Also, some Intel
+-    # versions had trouble with output in subdirs
+-    am__obj=sub/conftest.${OBJEXT-o}
+-    am__minus_obj="-o $am__obj"
+-    case $depmode in
+-    gcc)
+-      # This depmode causes a compiler race in universal mode.
+-      test "$am__universal" = false || continue
+-      ;;
+-    nosideeffect)
+-      # after this tag, mechanisms are not by side-effect, so they'll
+-      # only be used when explicitly requested
+-      if test "x$enable_dependency_tracking" = xyes; then
+-	continue
+-      else
+-	break
+-      fi
+-      ;;
+-    msvc7 | msvc7msys | msvisualcpp | msvcmsys)
+-      # This compiler won't grok `-c -o', but also, the minuso test has
+-      # not run yet.  These depmodes are late enough in the game, and
+-      # so weak that their functioning should not be impacted.
+-      am__obj=conftest.${OBJEXT-o}
+-      am__minus_obj=
+-      ;;
+-    none) break ;;
+-    esac
+-    if depmode=$depmode \
+-       source=sub/conftest.c object=$am__obj \
+-       depfile=sub/conftest.Po tmpdepfile=sub/conftest.TPo \
+-       $SHELL ./depcomp $depcc -c $am__minus_obj sub/conftest.c \
+-         >/dev/null 2>conftest.err &&
+-       grep sub/conftst1.h sub/conftest.Po > /dev/null 2>&1 &&
+-       grep sub/conftst6.h sub/conftest.Po > /dev/null 2>&1 &&
+-       grep $am__obj sub/conftest.Po > /dev/null 2>&1 &&
+-       ${MAKE-make} -s -f confmf > /dev/null 2>&1; then
+-      # icc doesn't choke on unknown options, it will just issue warnings
+-      # or remarks (even with -Werror).  So we grep stderr for any message
+-      # that says an option was ignored or not supported.
+-      # When given -MP, icc 7.0 and 7.1 complain thusly:
+-      #   icc: Command line warning: ignoring option '-M'; no argument required
+-      # The diagnosis changed in icc 8.0:
+-      #   icc: Command line remark: option '-MP' not supported
+-      if (grep 'ignoring option' conftest.err ||
+-          grep 'not supported' conftest.err) >/dev/null 2>&1; then :; else
+-        am_cv_CC_dependencies_compiler_type=$depmode
+-        break
+-      fi
+-    fi
+-  done
+-
+-  cd ..
+-  rm -rf conftest.dir
+-else
+-  am_cv_CC_dependencies_compiler_type=none
+-fi
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_CC_dependencies_compiler_type" >&5
+-$as_echo "$am_cv_CC_dependencies_compiler_type" >&6; }
+-CCDEPMODE=depmode=$am_cv_CC_dependencies_compiler_type
+-
+- if
+-  test "x$enable_dependency_tracking" != xno \
+-  && test "$am_cv_CC_dependencies_compiler_type" = gcc3; then
+-  am__fastdepCC_TRUE=
+-  am__fastdepCC_FALSE='#'
+-else
+-  am__fastdepCC_TRUE='#'
+-  am__fastdepCC_FALSE=
+-fi
+-
+-
+-
+-if test -n "$ac_tool_prefix"; then
+-  for ac_prog in ar lib "link -lib"
+-  do
+-    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
+-set dummy $ac_tool_prefix$ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_AR+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$AR"; then
+-  ac_cv_prog_AR="$AR" # Let the user override the test.
+-else
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_AR="$ac_tool_prefix$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-fi
+-fi
+-AR=$ac_cv_prog_AR
+-if test -n "$AR"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AR" >&5
+-$as_echo "$AR" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-    test -n "$AR" && break
+-  done
+-fi
+-if test -z "$AR"; then
+-  ac_ct_AR=$AR
+-  for ac_prog in ar lib "link -lib"
+-do
+-  # Extract the first word of "$ac_prog", so it can be a program name with args.
+-set dummy $ac_prog; ac_word=$2
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+-$as_echo_n "checking for $ac_word... " >&6; }
+-if ${ac_cv_prog_ac_ct_AR+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  if test -n "$ac_ct_AR"; then
+-  ac_cv_prog_ac_ct_AR="$ac_ct_AR" # Let the user override the test.
+-else
+-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+-for as_dir in $PATH
+-do
+-  IFS=$as_save_IFS
+-  test -z "$as_dir" && as_dir=.
+-    for ac_exec_ext in '' $ac_executable_extensions; do
+-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+-    ac_cv_prog_ac_ct_AR="$ac_prog"
+-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+-    break 2
+-  fi
+-done
+-  done
+-IFS=$as_save_IFS
+-
+-fi
+-fi
+-ac_ct_AR=$ac_cv_prog_ac_ct_AR
+-if test -n "$ac_ct_AR"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_AR" >&5
+-$as_echo "$ac_ct_AR" >&6; }
+-else
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+-$as_echo "no" >&6; }
+-fi
+-
+-
+-  test -n "$ac_ct_AR" && break
+-done
+-
+-  if test "x$ac_ct_AR" = x; then
+-    AR="false"
+-  else
+-    case $cross_compiling:$ac_tool_warned in
+-yes:)
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+-$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+-ac_tool_warned=yes ;;
+-esac
+-    AR=$ac_ct_AR
+-  fi
+-fi
+-
+-: ${AR=ar}
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking the archiver ($AR) interface" >&5
+-$as_echo_n "checking the archiver ($AR) interface... " >&6; }
+-if ${am_cv_ar_interface+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  am_cv_ar_interface=ar
+-   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-int some_variable = 0;
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-  am_ar_try='$AR cru libconftest.a conftest.$ac_objext >&5'
+-      { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$am_ar_try\""; } >&5
+-  (eval $am_ar_try) 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }
+-      if test "$ac_status" -eq 0; then
+-        am_cv_ar_interface=ar
+-      else
+-        am_ar_try='$AR -NOLOGO -OUT:conftest.lib conftest.$ac_objext >&5'
+-        { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$am_ar_try\""; } >&5
+-  (eval $am_ar_try) 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }
+-        if test "$ac_status" -eq 0; then
+-          am_cv_ar_interface=lib
+-        else
+-          am_cv_ar_interface=unknown
+-        fi
+-      fi
+-      rm -f conftest.lib libconftest.a
+-
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_ar_interface" >&5
+-$as_echo "$am_cv_ar_interface" >&6; }
+-
+-case $am_cv_ar_interface in
+-ar)
+-  ;;
+-lib)
+-  # Microsoft lib, so override with the ar-lib wrapper script.
+-  # FIXME: It is wrong to rewrite AR.
+-  # But if we don't then we get into trouble of one sort or another.
+-  # A longer-term fix would be to have automake use am__AR in this case,
+-  # and then we could set am__AR="$am_aux_dir/ar-lib \$(AR)" or something
+-  # similar.
+-  AR="$am_aux_dir/ar-lib $AR"
+-  ;;
+-unknown)
+-  as_fn_error $? "could not determine $AR interface" "$LINENO" 5
+-  ;;
+-esac
+-
+-
+ # Make sure we can run config.sub.
+ $SHELL "$ac_aux_dir/config.sub" sun4 >/dev/null 2>&1 ||
+   as_fn_error $? "cannot run $SHELL $ac_aux_dir/config.sub" "$LINENO" 5
+@@ -4770,6 +3627,256 @@
+   test $ac_status = 0; }
+ done
+ 
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main ()
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++ac_clean_files_save=$ac_clean_files
++ac_clean_files="$ac_clean_files a.out a.out.dSYM a.exe b.out"
++# Try to create an executable without -o first, disregard a.out.
++# It will help us diagnose broken compilers, and finding out an intuition
++# of exeext.
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
++$as_echo_n "checking whether the C compiler works... " >&6; }
++ac_link_default=`$as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
++
++# The possible output files:
++ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
++
++ac_rmfiles=
++for ac_file in $ac_files
++do
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
++    * ) ac_rmfiles="$ac_rmfiles $ac_file";;
++  esac
++done
++rm -f $ac_rmfiles
++
++if { { ac_try="$ac_link_default"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++$as_echo "$ac_try_echo"; } >&5
++  (eval "$ac_link_default") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then :
++  # Autoconf-2.13 could set the ac_cv_exeext variable to `no'.
++# So ignore a value of `no', otherwise this would lead to `EXEEXT = no'
++# in a Makefile.  We should not override ac_cv_exeext if it was cached,
++# so that the user can short-circuit this test for compilers unknown to
++# Autoconf.
++for ac_file in $ac_files ''
++do
++  test -f "$ac_file" || continue
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj )
++	;;
++    [ab].out )
++	# We found the default executable, but exeext='' is most
++	# certainly right.
++	break;;
++    *.* )
++	if test "${ac_cv_exeext+set}" = set && test "$ac_cv_exeext" != no;
++	then :; else
++	   ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
++	fi
++	# We set ac_cv_exeext here because the later test for it is not
++	# safe: cross compilers may not add the suffix if given an `-o'
++	# argument, so we may need to know it at that point already.
++	# Even if this section looks crufty: it has the advantage of
++	# actually working.
++	break;;
++    * )
++	break;;
++  esac
++done
++test "$ac_cv_exeext" = no && ac_cv_exeext=
++
++else
++  ac_file=''
++fi
++if test -z "$ac_file"; then :
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++$as_echo "$as_me: failed program was:" >&5
++sed 's/^/| /' conftest.$ac_ext >&5
++
++{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error 77 "C compiler cannot create executables
++See \`config.log' for more details" "$LINENO" 5; }
++else
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
++$as_echo "yes" >&6; }
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
++$as_echo_n "checking for C compiler default output file name... " >&6; }
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
++$as_echo "$ac_file" >&6; }
++ac_exeext=$ac_cv_exeext
++
++rm -f -r a.out a.out.dSYM a.exe conftest$ac_cv_exeext b.out
++ac_clean_files=$ac_clean_files_save
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
++$as_echo_n "checking for suffix of executables... " >&6; }
++if { { ac_try="$ac_link"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++$as_echo "$ac_try_echo"; } >&5
++  (eval "$ac_link") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then :
++  # If both `conftest.exe' and `conftest' are `present' (well, observable)
++# catch `conftest.exe'.  For instance with Cygwin, `ls conftest' will
++# work properly (i.e., refer to `conftest.exe'), while it won't with
++# `rm'.
++for ac_file in conftest.exe conftest conftest.*; do
++  test -f "$ac_file" || continue
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM | *.o | *.obj ) ;;
++    *.* ) ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
++	  break;;
++    * ) break;;
++  esac
++done
++else
++  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error $? "cannot compute suffix of executables: cannot compile and link
++See \`config.log' for more details" "$LINENO" 5; }
++fi
++rm -f conftest conftest$ac_cv_exeext
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
++$as_echo "$ac_cv_exeext" >&6; }
++
++rm -f conftest.$ac_ext
++EXEEXT=$ac_cv_exeext
++ac_exeext=$EXEEXT
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++#include <stdio.h>
++int
++main ()
++{
++FILE *f = fopen ("conftest.out", "w");
++ return ferror (f) || fclose (f) != 0;
++
++  ;
++  return 0;
++}
++_ACEOF
++ac_clean_files="$ac_clean_files conftest.out"
++# Check that the compiler produces executables we can run.  If not, either
++# the compiler is broken, or we cross compile.
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
++$as_echo_n "checking whether we are cross compiling... " >&6; }
++if test "$cross_compiling" != yes; then
++  { { ac_try="$ac_link"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++$as_echo "$ac_try_echo"; } >&5
++  (eval "$ac_link") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++  if { ac_try='./conftest$ac_cv_exeext'
++  { { case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++$as_echo "$ac_try_echo"; } >&5
++  (eval "$ac_try") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }; then
++    cross_compiling=no
++  else
++    if test "$cross_compiling" = maybe; then
++	cross_compiling=yes
++    else
++	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error $? "cannot run C compiled programs.
++If you meant to cross compile, use \`--host'.
++See \`config.log' for more details" "$LINENO" 5; }
++    fi
++  fi
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
++$as_echo "$cross_compiling" >&6; }
++
++rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out
++ac_clean_files=$ac_clean_files_save
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
++$as_echo_n "checking for suffix of object files... " >&6; }
++if ${ac_cv_objext+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++
++int
++main ()
++{
++
++  ;
++  return 0;
++}
++_ACEOF
++rm -f conftest.o conftest.obj
++if { { ac_try="$ac_compile"
++case "(($ac_try" in
++  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
++  *) ac_try_echo=$ac_try;;
++esac
++eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
++$as_echo "$ac_try_echo"; } >&5
++  (eval "$ac_compile") 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then :
++  for ac_file in conftest.o conftest.obj conftest.*; do
++  test -f "$ac_file" || continue;
++  case $ac_file in
++    *.$ac_ext | *.xcoff | *.tds | *.d | *.pdb | *.xSYM | *.bb | *.bbg | *.map | *.inf | *.dSYM ) ;;
++    *) ac_cv_objext=`expr "$ac_file" : '.*\.\(.*\)'`
++       break;;
++  esac
++done
++else
++  $as_echo "$as_me: failed program was:" >&5
++sed 's/^/| /' conftest.$ac_ext >&5
++
++{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
++$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
++as_fn_error $? "cannot compute suffix of object files: cannot compile
++See \`config.log' for more details" "$LINENO" 5; }
++fi
++rm -f conftest.$ac_cv_objext conftest.$ac_ext
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
++$as_echo "$ac_cv_objext" >&6; }
++OBJEXT=$ac_cv_objext
++ac_objext=$OBJEXT
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C compiler" >&5
+ $as_echo_n "checking whether we are using the GNU C compiler... " >&6; }
+ if ${ac_cv_c_compiler_gnu+:} false; then :
+@@ -4980,6 +4087,69 @@
+ ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
++DEPDIR="${am__leading_dot}deps"
++
++ac_config_commands="$ac_config_commands depfiles"
++
++
++am_make=${MAKE-make}
++cat > confinc << 'END'
++am__doit:
++	@echo this is the am__doit target
++.PHONY: am__doit
++END
++# If we don't find an include directive, just comment out the code.
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for style of include used by $am_make" >&5
++$as_echo_n "checking for style of include used by $am_make... " >&6; }
++am__include="#"
++am__quote=
++_am_result=none
++# First try GNU make style include.
++echo "include confinc" > confmf
++# Ignore all kinds of additional output from `make'.
++case `$am_make -s -f confmf 2> /dev/null` in #(
++*the\ am__doit\ target*)
++  am__include=include
++  am__quote=
++  _am_result=GNU
++  ;;
++esac
++# Now try BSD make style include.
++if test "$am__include" = "#"; then
++   echo '.include "confinc"' > confmf
++   case `$am_make -s -f confmf 2> /dev/null` in #(
++   *the\ am__doit\ target*)
++     am__include=.include
++     am__quote="\""
++     _am_result=BSD
++     ;;
++   esac
++fi
++
++
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $_am_result" >&5
++$as_echo "$_am_result" >&6; }
++rm -f confinc confmf
++
++# Check whether --enable-dependency-tracking was given.
++if test "${enable_dependency_tracking+set}" = set; then :
++  enableval=$enable_dependency_tracking;
++fi
++
++if test "x$enable_dependency_tracking" != xno; then
++  am_depcomp="$ac_aux_dir/depcomp"
++  AMDEPBACKSLASH='\'
++  am__nodep='_no'
++fi
++ if test "x$enable_dependency_tracking" != xno; then
++  AMDEP_TRUE=
++  AMDEP_FALSE='#'
++else
++  AMDEP_TRUE='#'
++  AMDEP_FALSE=
++fi
++
++
+ 
+ depcc="$CC"   am_compiler_list=
+ 
+@@ -5116,6 +4286,171 @@
+ ac_compiler_gnu=$ac_cv_c_compiler_gnu
+ 
+ 
++# Automake 1.12 seems to require this, but automake 1.11 doesn't recognize it.
++# Do not call AM_PROG_AR before MPC_GMP_CC_CFLAGS, since otherwise ac_cv_prog_CC
++# is already set and overrides our CC setting (which may come from gmp.h).
++
++if test -n "$ac_tool_prefix"; then
++  for ac_prog in ar lib "link -lib"
++  do
++    # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
++set dummy $ac_tool_prefix$ac_prog; ac_word=$2
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++$as_echo_n "checking for $ac_word... " >&6; }
++if ${ac_cv_prog_AR+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  if test -n "$AR"; then
++  ac_cv_prog_AR="$AR" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  test -z "$as_dir" && as_dir=.
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++    ac_cv_prog_AR="$ac_tool_prefix$ac_prog"
++    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++AR=$ac_cv_prog_AR
++if test -n "$AR"; then
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AR" >&5
++$as_echo "$AR" >&6; }
++else
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++fi
++
++
++    test -n "$AR" && break
++  done
++fi
++if test -z "$AR"; then
++  ac_ct_AR=$AR
++  for ac_prog in ar lib "link -lib"
++do
++  # Extract the first word of "$ac_prog", so it can be a program name with args.
++set dummy $ac_prog; ac_word=$2
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
++$as_echo_n "checking for $ac_word... " >&6; }
++if ${ac_cv_prog_ac_ct_AR+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  if test -n "$ac_ct_AR"; then
++  ac_cv_prog_ac_ct_AR="$ac_ct_AR" # Let the user override the test.
++else
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  test -z "$as_dir" && as_dir=.
++    for ac_exec_ext in '' $ac_executable_extensions; do
++  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
++    ac_cv_prog_ac_ct_AR="$ac_prog"
++    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
++    break 2
++  fi
++done
++  done
++IFS=$as_save_IFS
++
++fi
++fi
++ac_ct_AR=$ac_cv_prog_ac_ct_AR
++if test -n "$ac_ct_AR"; then
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_AR" >&5
++$as_echo "$ac_ct_AR" >&6; }
++else
++  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
++$as_echo "no" >&6; }
++fi
++
++
++  test -n "$ac_ct_AR" && break
++done
++
++  if test "x$ac_ct_AR" = x; then
++    AR="false"
++  else
++    case $cross_compiling:$ac_tool_warned in
++yes:)
++{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
++$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
++ac_tool_warned=yes ;;
++esac
++    AR=$ac_ct_AR
++  fi
++fi
++
++: ${AR=ar}
++
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking the archiver ($AR) interface" >&5
++$as_echo_n "checking the archiver ($AR) interface... " >&6; }
++if ${am_cv_ar_interface+:} false; then :
++  $as_echo_n "(cached) " >&6
++else
++  am_cv_ar_interface=ar
++   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++int some_variable = 0;
++_ACEOF
++if ac_fn_c_try_compile "$LINENO"; then :
++  am_ar_try='$AR cru libconftest.a conftest.$ac_objext >&5'
++      { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$am_ar_try\""; } >&5
++  (eval $am_ar_try) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++      if test "$ac_status" -eq 0; then
++        am_cv_ar_interface=ar
++      else
++        am_ar_try='$AR -NOLOGO -OUT:conftest.lib conftest.$ac_objext >&5'
++        { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$am_ar_try\""; } >&5
++  (eval $am_ar_try) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }
++        if test "$ac_status" -eq 0; then
++          am_cv_ar_interface=lib
++        else
++          am_cv_ar_interface=unknown
++        fi
++      fi
++      rm -f conftest.lib libconftest.a
++
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++
++fi
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $am_cv_ar_interface" >&5
++$as_echo "$am_cv_ar_interface" >&6; }
++
++case $am_cv_ar_interface in
++ar)
++  ;;
++lib)
++  # Microsoft lib, so override with the ar-lib wrapper script.
++  # FIXME: It is wrong to rewrite AR.
++  # But if we don't then we get into trouble of one sort or another.
++  # A longer-term fix would be to have automake use am__AR in this case,
++  # and then we could set am__AR="$am_aux_dir/ar-lib \$(AR)" or something
++  # similar.
++  AR="$am_aux_dir/ar-lib $AR"
++  ;;
++unknown)
++  as_fn_error $? "could not determine $AR interface" "$LINENO" 5
++  ;;
++esac
++
++
+ # Set up LibTool
+ case `pwd` in
+   *\ * | *\	*)
+@@ -14665,7 +14000,7 @@
+ 
+          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for current svn version" >&5
+ $as_echo_n "checking for current svn version... " >&6; }
+-         SVNVERSION=1241M
++         SVNVERSION=exported
+ 
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SVNVERSION" >&5
+ $as_echo "$SVNVERSION" >&6; }
+@@ -14805,10 +14140,6 @@
+   as_fn_error $? "conditional \"am__fastdepCC\" was never defined.
+ Usually this means the macro was only invoked conditionally." "$LINENO" 5
+ fi
+-if test -z "${am__fastdepCC_TRUE}" && test -z "${am__fastdepCC_FALSE}"; then
+-  as_fn_error $? "conditional \"am__fastdepCC\" was never defined.
+-Usually this means the macro was only invoked conditionally." "$LINENO" 5
+-fi
+ 
+ : "${CONFIG_STATUS=./config.status}"
+ ac_write_fail=0
+diff -rud src/Makefile.in b/Makefile.in
+--- src/Makefile.in	2012-07-19 14:33:58.000000000 +0200
++++ b/Makefile.in	2012-08-01 15:56:48.000000000 +0200
+@@ -1,4 +1,4 @@
+-# Makefile.in generated by automake 1.11.5 from Makefile.am.
++# Makefile.in generated by automake 1.11.6 from Makefile.am.
+ # @configure_input@
+ 
+ # Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,
+@@ -634,7 +634,7 @@
+ 	*.zip*) \
+ 	  unzip $(distdir).zip ;;\
+ 	esac
+-	chmod -R a-w $(distdir); chmod a+w $(distdir)
++	chmod -R a-w $(distdir); chmod u+w $(distdir)
+ 	mkdir $(distdir)/_build
+ 	mkdir $(distdir)/_inst
+ 	chmod a-w $(distdir)
+diff -rud src/doc/Makefile.in b/doc/Makefile.in
+--- src/doc/Makefile.in	2012-07-19 14:33:58.000000000 +0200
++++ b/doc/Makefile.in	2012-08-01 15:56:47.000000000 +0200
+@@ -1,4 +1,4 @@
+-# Makefile.in generated by automake 1.11.5 from Makefile.am.
++# Makefile.in generated by automake 1.11.6 from Makefile.am.
+ # @configure_input@
+ 
+ # Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,
+diff -rud src/src/Makefile.in b/src/Makefile.in
+--- src/src/Makefile.in	2012-07-19 14:33:58.000000000 +0200
++++ b/src/Makefile.in	2012-08-01 15:56:47.000000000 +0200
+@@ -1,4 +1,4 @@
+-# Makefile.in generated by automake 1.11.5 from Makefile.am.
++# Makefile.in generated by automake 1.11.6 from Makefile.am.
+ # @configure_input@
+ 
+ # Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,
+diff -rud src/tests/Makefile.in b/tests/Makefile.in
+--- src/tests/Makefile.in	2012-07-19 14:33:58.000000000 +0200
++++ b/tests/Makefile.in	2012-08-01 15:56:47.000000000 +0200
+@@ -1,4 +1,4 @@
+-# Makefile.in generated by automake 1.11.5 from Makefile.am.
++# Makefile.in generated by automake 1.11.6 from Makefile.am.
+ # @configure_input@
+ 
+ # Copyright (C) 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002,

--- a/build/pkgs/mpc/spkg-install
+++ b/build/pkgs/mpc/spkg-install
@@ -11,7 +11,7 @@ cd src
 # Apply patches.  See SPKG.txt for information about what each patch
 # does.
 for patch in ../patches/*.patch; do
-    [ -r "$patch" ] || continue
+    [ -r "$patch" ] || continue  # Skip non-existing or non-readable patches
     patch -p1 <"$patch"
     if [ $? -ne 0 ]; then
         echo >&2 "Error applying '$patch'"


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13290">trac #13290</a>.

Patch for the mpc spkg, for review only

Reported by: jdemeyer

Component: packages

CC: jpflori,, zimmerma

Report Upstream: Fixed upstream, in a later stable release.

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Leif Leonhardy, Volker Braun

Merged in: sage-5.3.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13290/mpc-1.0.spkg-gcc-4.7.0-config.log">mpc-1.0.spkg-gcc-4.7.0-config.log: `config.log` from MPC 1.0 spkg showing use of `gcc` instead of `gmp.h`'s CC</a> by leif at 20120727T15:41:20</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13290/configure.ac.patch">configure.ac.patch: "Upstream" patch to `configure.ac` to fix `CC` not being taken from `gmp.h`.</a> by leif at 20120727T20:25:31</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13290/13290_mpc_1_0.patch">13290_mpc_1_0.patch: Patch for the Sage library</a> by jdemeyer at 20120801T14:16:12</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13290/mpc-1.0.p0.diff">mpc-1.0.p0.diff: Patch for the mpc spkg, for review only</a> by jdemeyer at 20120801T14:19:24</li></ol>
