### PR TITLE
Race condition in R installation

### DIFF
--- a/build/pkgs/r/SPKG.txt
+++ b/build/pkgs/r/SPKG.txt
@@ -33,8 +33,13 @@
      The corresponding patch to m4/clibs.m4 is not included, as
      autoconf-2.68 gives errors, even on the clean upstream sources.
    - R.sh.in: Set R_HOME_DIR to "${SAGE_LOCAL}/lib/R/" when running R.
+   - install_parallel.patch: fix parallel installation, see
+     https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=15041
 
 == Changelog ==
+
+=== r-2.14.0.p4 (Jeroen Demeyer, 4 September 2012 ===
+ * #13428: add patch install_parallel.patch
 
 === r-2.14.0.p3 (Jeroen Demeyer, 30 March 2012) ===
  * #12787: use -### instead of -v to detect linker options

--- a/build/pkgs/r/patches/install_parallel.patch
+++ b/build/pkgs/r/patches/install_parallel.patch
@@ -1,0 +1,12 @@
+diff -ru R-2.15.1/src/include/Makefile.in R-2.15.1-fixed/src/include/Makefile.in
+--- R-2.15.1/src/include/Makefile.in	2011-02-27 00:05:04.000000000 +0100
++++ R-2.15.1-fixed/src/include/Makefile.in	2012-09-04 11:30:54.004362821 +0200
+@@ -93,7 +93,7 @@
+ 	done
+ installdirs:
+ 	@$(MKINSTALLDIRS) "$(DESTDIR)$(rincludedir)@R_ARCH@"
+-install-intl-yes:
++install-intl-yes: installdirs
+ 	@$(INSTALL_DATA) libintl.h "$(DESTDIR)$(rincludedir)@R_ARCH@"
+ install-intl-no:
+ 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13428">trac #13428</a>.

Diff for the R spkg. For reference / review only.

Reported by: jdemeyer

Component: packages

CC: jhpalmieri

Report Upstream: Fixed upstream, in a later stable release.

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: John Palmieri

Merged in: sage-5.4.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13428/r-2.14.0.p4.diff">r-2.14.0.p4.diff: Diff for the R spkg. For reference / review only.</a> by jdemeyer at 20120904T12:09:44</li></ol>
