### PR TITLE
Remove old docs when upgrading sagenb

### DIFF
--- a/build/pkgs/sagenb/spkg-install
+++ b/build/pkgs/sagenb/spkg-install
@@ -91,3 +91,8 @@ else
 fi
 mv -f easy-install.pth.$$ easy-install.pth ||
     die "Error overwriting original 'easy-install.pth'."
+
+# Remove old reference manual to fix upgrading from sage-5.1 or
+# earlier.  Some old .rst files might try to import modules which no
+# longer exist, see #13405.
+rm -rf "$SAGE_ROOT/devel/sage/doc/en/reference/sagenb"


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13405">trac #13405</a>.

Reported by: jdemeyer

Component: build

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer, Keshav Kini

Dependencies: 

Work issues: 

Reviewers: John Palmieri

Merged in: sage-5.3.rc1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13405/sagenb-0.9.2.diff">sagenb-0.9.2.diff: </a> by jdemeyer at 20120829T10:13:36</li></ol>
