### PR TITLE
segmentation fault with roots over ComplexField

### DIFF
--- a/build/pkgs/pari/SPKG.txt
+++ b/build/pkgs/pari/SPKG.txt
@@ -69,6 +69,9 @@ of doubt, have a look at the file spkg-src.
 
 == Changelog ==
 
+=== pari-2.5.2.p1 (Paul Zimmermann, 28 August 2012) ===
+ * Ticket #13314: add upstream patch rootpol.patch for rootpol().
+
 === pari-2.5.2.p0 (Jeroen Demeyer, 1 August 2012) ===
  * Ticket #13320: upgrade to version 2.5.2
  * Rename spkg-make to spkg-src

--- a/build/pkgs/pari/patches/README.txt
+++ b/build/pkgs/pari/patches/README.txt
@@ -42,3 +42,4 @@ C files:
   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=49330
   This bug manifests itself as a Bus Error on OS X 10.4 PPC with
   gcc-4.6.3.
+* rootpol.patch: fixes a Segmentation Fault in Sage "roots" (#13314)

--- a/build/pkgs/pari/patches/rootpol.patch
+++ b/build/pkgs/pari/patches/rootpol.patch
@@ -1,0 +1,33 @@
+    fix typo introduced in 7b985ff8a726e89191d2733b9052b2e2c228bfde
+    "minor improvements root_error()"
+    prod was not re-initialized to 1.
+
+diff --git a/src/basemath/rootpol.c b/src/basemath/rootpol.c
+index 3099bb2..0be400f 100644
+--- a/src/basemath/rootpol.c
++++ b/src/basemath/rootpol.c
+@@ -1611,8 +1611,8 @@ split_0(GEN p, long bit, GEN *F, GEN *G)
+ static GEN
+ root_error(long n, long k, GEN roots_pol, long pari_err, GEN shatzle)
+ {
+-  GEN rho, d, eps, epsbis, eps2, prod, aux, rap = NULL;
+-  long i, j, m;
++  GEN rho, d, eps, epsbis, eps2, aux, rap = NULL;
++  long i, j;
+
+   d = cgetg(n+1,t_VEC);
+   for (i=1; i<=n; i++)
+@@ -1627,11 +1627,11 @@ root_error(long n, long k, GEN roots_pol, long pari_err, GEN shatzle)
+   if (expo(rho) < 0) rho = real_1(DEFAULTPREC);
+   eps = mulrr(rho, shatzle);
+   aux = shiftr(powru(rho,n), pari_err);
+-  prod = NULL; /* 1. */
+
+   for (j=1; j<=2 || (j<=5 && cmprr(rap, dbltor(1.2)) > 0); j++)
+   {
+-    m = n;
++    GEN prod = NULL; /* 1. */
++    long m = n;
+     epsbis = mulrr(eps, dbltor(1.25));
+     for (i=1; i<=n; i++)
+     {


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13314">trac #13314</a>.

Reported by: zimmerma

Component: calculus

CC: jdemeyer,, cremona

Report Upstream: Fixed upstream, but not in a stable release.

Authors: Paul Zimmermann, Jeroen Demeyer

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/13320">trac #13320</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/12346">trac #12346</a>

Work issues: 

Reviewers: John Cremona

Merged in: sage-5.4.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13314/pari-2.5.2.p1.diff">pari-2.5.2.p1.diff: </a> by jdemeyer at 20120829T12:56:41</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13314/13314_polroots_test.patch">13314_polroots_test.patch: </a> by jdemeyer at 20120903T11:42:14</li></ol>
