### PR TITLE
Upgrade Singular

### DIFF
--- a/build/pkgs/singular/SPKG.txt
+++ b/build/pkgs/singular/SPKG.txt
@@ -31,6 +31,8 @@ See spkg-changes for how to delete unnecessary stuff under src/
 
 Several patches are applied.
  * assert.patch: logic seems to be broken on some platforms
+ * install_table.patch: install singular/table.h header file, needed
+   for the libsing GAP package.
  * Minor.h.patch: needs to have <time.h> included on Cygwin
  * NTL_negate.patch: change negate() to NTL::negate() to fix a conflict
    with std::negate(). See
@@ -69,6 +71,9 @@ Other notes
    (configure --with-flint="$SAGE_LOCAL").
 
 == ChangeLog ==
+
+=== singular-3-1-5.p1 (Simon King, 29 August 2012) ===
+ * Trac #13237: add patch install_table.patch
 
 === singular-3-1-5.p0 (Jeroen Demeyer, Alexander Dreyer, 10 August 2012) ===
  * Trac #13237: Upgrade to version 3-1-5.

--- a/build/pkgs/singular/patches/install_table.patch
+++ b/build/pkgs/singular/patches/install_table.patch
@@ -1,0 +1,10 @@
+--- src/Singular/Makefile.in    2012-07-11 11:00:13.000000000 +0100
++++ src/Singular/Makefile.in    2012-08-27 16:22:26.013159361 +0100
+@@ -599,7 +599,7 @@
+ 	  ${INSTALL_PROGRAM}  $$file ${libdir}; \
+ 	done
+ 	${INSTALL_PROGRAM} libsingular.h ${includedir}
+-	for file in subexpr.h tok.h grammar.h ipid.h lists.h ipshell.h attrib.h; do \
++	for file in subexpr.h tok.h grammar.h ipid.h lists.h ipshell.h attrib.h table.h; do \
+ 	sed -e "s:<kernel/:<singular/:" < $$file |sed -e "s:<Singular/:<singular/:"|sed -e "s:<omalloc/:<:"|sed -e "s:<factory/:<:" >${includedir}/singular/$$file ;\
+ 	done


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13237">trac #13237</a>.

Diff for the singular spkg p0->p1. For reference / review only.

Reported by: jdemeyer

Component: packages

CC: fbissey,, malb,, jpflori

Report Upstream: None of the above - read trac for reasoning.

Authors: Jeroen Demeyer, Alexander Dreyer, Dmitrii Pasechnik, Karl-Dieter Crisman, Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Alexander Dreyer, François Bissey

Merged in: sage-5.4.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13237/13237_singular_3_1_5.patch">13237_singular_3_1_5.patch: Patch for the Sage library</a> by jdemeyer at 20120802T10:04:45</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13237/singular-3-1-5.p0.diff">singular-3-1-5.p0.diff: Diff for the singular spkg. For reference / review only.</a> by jdemeyer at 20120810T21:00:58</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13237/13237_tests.patch">13237_tests.patch: Additional patch</a> by jdemeyer at 20120827T10:34:01</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13237/singular-3-1-5.p1.diff">singular-3-1-5.p1.diff: Diff for the singular spkg p0->p1. For reference / review only.</a> by jdemeyer at 20120829T09:39:39</li></ol>
