### PR TITLE
GAP's spkg-install fails on recent Cygwin

### DIFF
--- a/build/pkgs/gap/SPKG.txt
+++ b/build/pkgs/gap/SPKG.txt
@@ -55,6 +55,9 @@ Steve Linton, sal@dcs.st-and.ac.uk, is basically the lead developer)
 
 == Changelog ==
 
+=== gap-4.4.12.p8 (Jean-Pierre Flori, Leif Leonhardy, 5 August 2012) ===
+ * #13341: Only create symbolic link to gap.exe on Cygwin if needed.
+
 === gap-4.4.12.p7 (Leif Leonhardy, March 22nd 2012) ===
  * #7041: Only unset `CC` and `CXX` if really necessary (i.e., if they
    contain spaces, which is what currently would break the build).

--- a/build/pkgs/gap/spkg-install
+++ b/build/pkgs/gap/spkg-install
@@ -92,18 +92,33 @@ build()
         exit 1
     fi
 
-    # On a Windows machine the GAP build creates a file "gap.exe",
-    # but no file named "gap".  This breaks the build, since it
-    # then tries to strip gap, but can't since the file is missing!
+    # On Cygwin installations the GAP build creates a file 'gap.exe',
+    # and then tries to strip the file 'gap'.
+    # This broke the build on old Cygwin installations.
+    # On newer Cygwins, 'gap' is automatically "translated" to 'gap.exe'.
     if [[ "$UNAME" = CYGWIN ]]; then
+        echo "Creating a dummy 'gap.exe' in 'bin/i686-pc-cygwin-gcc'..."
         mkdir -p bin/i686-pc-cygwin-gcc &&
         cd bin/i686-pc-cygwin-gcc &&
-        touch gap.exe &&
-        ln -s gap.exe gap
+        touch gap.exe
         if [[ $? -ne 0 ]]; then
-            echo >&2 "Error creating dummy 'gap.exe' and/or a link from 'gap' to it."
+            # Something really went wrong.
+            echo >&2 "Error creating a dummy gap.exe file."
             exit 1
         fi
+
+        # Check if 'gap' is automatically "translated" to 'gap.exe'.
+        # If not, create a symbolic link from 'gap' to 'gap.exe'.
+        if [[ ! -f gap ]]; then
+            echo "Creating a symbolic link from 'gap' to 'gap.exe'..."
+            ln -s gap.exe gap
+            if [[ $? -ne 0 ]]; then
+                # Something really went wrong.
+                echo >&2 "Error creating the symbolic link."
+                exit 1
+            fi
+        fi
+
         cd ../..
     fi
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13341">trac #13341</a>.

spkg diff, for review only

Reported by: jpflori

Component: cygwin

CC: dimpase

Report Upstream: N/A

Authors: Jean-Pierre Flori, Leif Leonhardy

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.3.rc1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13341/spkg.diff">spkg.diff: Spkg diff, for review only.</a> by jpflori at 20120805T10:02:35</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13341/spkg.2.diff">spkg.2.diff: spkg diff, for review only</a> by jpflori at 20120805T19:39:08</li></ol>
