### PR TITLE
flint-1.5.2.p0.spkg installation fails on Cygwin

### DIFF
--- a/build/pkgs/flint/SPKG.txt
+++ b/build/pkgs/flint/SPKG.txt
@@ -36,6 +36,10 @@ GPL V2+
 
 == Changelog ==
 
+=== flint-1.5.2.p1 (Jean-Pierre Flori, 3 August 2012) ===
+  * #13330: Pass --binary flag to patch on Cygwin to deal with file terminators
+            mess.
+
 === flint-1.5.2.p0 (Dima Pasechnik, March 24th 2012) ===
   * bumped up the version to reflect the fact that we patch the source
 

--- a/build/pkgs/flint/spkg-install
+++ b/build/pkgs/flint/spkg-install
@@ -73,10 +73,13 @@ FLINT_LINK_OPTIONS=""
 export FLINT_LINK_OPTIONS
 
 # Apply all patches
+if [ $UNAME = "CYGWIN" ]; then
+    PATCH_FLAG=--binary
+fi
 cd src
 echo "Patching Flint"
 for p in ../patches/*.patch; do
-    patch -p1 <"$p"
+    patch $PATCH_FLAG -p1 <"$p"
     if [ $? -ne 0 ]; then
         echo "Applying patch $p failed"
         exit 1


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13330">trac #13330</a>.

Spkg diff, for review only.

Reported by: jpflori

Component: cygwin

CC: 

Report Upstream: N/A

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.3.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13330/spkg.diff">spkg.diff: Spkg diff, for review only.</a> by jpflori at 20120803T09:50:31</li></ol>
