### PR TITLE
Update pynac to version 0.2.5

### DIFF
--- a/build/pkgs/pynac/SPKG.txt
+++ b/build/pkgs/pynac/SPKG.txt
@@ -32,6 +32,10 @@ in the src directory.
 
 == Changelog ==
 
+=== pynac-0.2.5 (Jean-Pierre Flori, 31 July 2012) ===
+ * Trac #13316: update to verson 0.2.5.
+ * Trac #13107: fix division by Python longs.
+
 === pynac-0.2.4 (Jean-Pierre Flori, 23 May 2012) ===
  * Trac #12950: Include patches to fix:
   * Trac #11155: abs(pi + I) -> pi + I


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13316">trac #13316</a>.

A new version of pynac was recently released and fixes some bugs.
Let's include that new version in Sage.

Try the spkg at:
http://perso.telecom-paristech.fr/~flori/sage/pynac-0.2.5.spkg

Ticket <a href="http://trac.sagemath.org/sage_trac/ticket/13107">trac #13107</a> in dependencies includes the related doctests.

Reported by: jpflori

Component: symbolics

CC: burcin,, jpflori,, kcrisman

Report Upstream: N/A

Authors: Jean-Pierre Flori

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/13107">trac #13107</a>

Work issues: 

Reviewers: Burcin Erocal

Merged in: sage-5.4.beta2

Attachments: <ol></ol>
