### PR TITLE
Allow building Sage with GCC-4.7.x

### DIFF
--- a/build/pkgs/zn_poly/SPKG.txt
+++ b/build/pkgs/zn_poly/SPKG.txt
@@ -34,13 +34,6 @@ the file src/COPYING for details.
    `spkg-install` (and perhaps also `spkg-check`).
  * There's also a `--use-flint` option to `configure`; no idea what it does,
    and we currently don't use it either.
- * Check whether the work-around for GCC 4.7 on ia64 is still appropriate, i.e.
-   adapt it in case the issue has been fixed in later GCC versions of the 4.7
-   release series.  (Although the bug currently affects only GCC 4.7.0, it
-   seems unlikely that it will be fixed soon, hence we apply the work-around
-   for any GCC 4.7.x version on ia64.)
-   See http://gcc.gnu.org/bugzilla/show_bug.cgi?id=48496 for details and the
-   current status of that bug.
  * TODO:
    - Use `make install` instead of manually "installing" (copying and sym-
      linking) the [shared] libraries and header files.  This requires further
@@ -63,6 +56,12 @@ the file src/COPYING for details.
    (See #8771).
 
 == Changelog ==
+
+=== zn_poly-0.9.p9 (Jeroen Demeyer, 28 May 2012) ===
+ * Trac #12751: remove the gcc-4.7.0 workaround for ia64 since this bug
+   has been fixed in gcc-4.7.1 and we will not fully support building
+   Sage with gcc-4.7.0 on Itanium.
+ * Don't override user-set CFLAGS and CXXFLAGS.
 
 === zn_poly-0.9.p8 (Leif Leonhardy, April 20th, 2012) ===
  * #12433: Further reviewer changes / additions.

--- a/build/pkgs/zn_poly/spkg-install
+++ b/build/pkgs/zn_poly/spkg-install
@@ -35,28 +35,11 @@ fi
 
 if [ "$SAGE_DEBUG" = yes ]; then
     echo >&2 "Warning: Setting SAGE_DEBUG to 'yes' completely disables optimization."
-    CFLAGS="$CFLAGS -O0 -g -fPIC"
-    CXXFLAGS="$CXXFLAGS -O0 -g -fPIC"
+    CFLAGS="-O0 -g $CFLAGS -fPIC"
+    CXXFLAGS="-O0 -g $CXXFLAGS -fPIC"
 else
     CFLAGS="-O3 -g $CFLAGS -fPIC"
     CXXFLAGS="-O3 -g $CXXFLAGS -fPIC"
-fi
-
-# Work around a bug in GCC 4.7.0 which breaks the build on Itanium CPUs with
-# '-O3', '-O2' and '-O1' (cf. #12765, #12751, and the bug URL below.)
-if [ "`uname -m`" = ia64 ] && [ "`testcc.sh $CC`" = GCC ]; then
-    gcc_version=`$CC -dumpversion`
-    case "$gcc_version" in
-      4.7.*)
-        CFLAGS="$CFLAGS -O0 -finline-functions -fschedule-insns"
-        CXXFLAGS="$CXXFLAGS -O0 -finline-functions -fschedule-insns"
-        echo >&2 "Warning: Disabling almost all optimization due to a bug in (at least)"
-        echo >&2 "         GCC 4.7.0 on Itanium, which otherwise would break the build."
-        echo >&2 "         See http://gcc.gnu.org/bugzilla/show_bug.cgi?id=48496"
-        echo >&2 "         for current status and further details."
-        echo >&2 "         (And please report to e.g. sage-devel in case you feel this bug"
-        echo >&2 "          should already be fixed in GCC $gcc_version.)"
-    esac
 fi
 
 export CFLAGS CPPFLAGS CXXFLAGS LDFLAGS # Partially redundant, but safe.


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12751">trac #12751</a>.

Apply to SAGE_ROOT

Reported by: mariah

Component: build

CC: jdemeyer,, leif

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Volker Braun

Merged in: sage-5.2.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12751/ecm-6.3.p8.diff">ecm-6.3.p8.diff: Diff for the ecm spkg. For reference / review only.</a> by jdemeyer at 20120529T02:21:29</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12751/mpfr-3.1.0.p2.diff">mpfr-3.1.0.p2.diff: Diff for the mpfr spkg. For reference / review only.</a> by jdemeyer at 20120529T02:21:46</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12751/mpir-2.4.0.p6.diff">mpir-2.4.0.p6.diff: Diff for the mpir spkg. For reference / review only.</a> by jdemeyer at 20120529T02:22:04</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12751/zn_poly-0.9.p9.diff">zn_poly-0.9.p9.diff: Diff for the zn_poly spkg. For reference / review only.</a> by jdemeyer at 20120529T02:22:21</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12751/12751_allow_gcc_4_7.patch">12751_allow_gcc_4_7.patch: Apply to SAGE_ROOT</a> by jdemeyer at 20120529T03:02:24</li></ol>
