### PR TITLE
Run _write_started_file() only from sage-starts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,10 @@ ssl: all
 build-serial: SAGE_PARALLEL_SPKG_BUILD = no
 build-serial: build
 
-# Start Sage if the file local/lib/sage-started.txt does not exist
-# (i.e. when we just installed Sage for the first time)
+# Start Sage if the file local/etc/sage-started.txt does not exist
+# (i.e. when we just installed Sage for the first time).
 start: build
-	[ -f local/lib/sage-started.txt ] || local/bin/sage-starts
+	[ -f local/etc/sage-started.txt ] || local/bin/sage-starts
 
 # You can choose to have the built HTML version of the documentation link to
 # the PDF version. To do so, you need to build both the HTML and PDF versions.


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13988">trac #13988</a>.

Reported by: jdemeyer

Component: build

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Volker Braun

Merged in: sage-5.7.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13988/13988_starts_root.patch">13988_starts_root.patch: </a> by jdemeyer at 20130122T21:25:09</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13988/13988_starts_scripts.patch">13988_starts_scripts.patch: </a> by jdemeyer at 20130122T21:25:30</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13988/13988_write_started_file.patch">13988_write_started_file.patch: </a> by jdemeyer at 20130122T21:25:47</li></ol>
