### PR TITLE
Set Fortran compiler variables

### DIFF
--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -443,8 +443,18 @@ fi
 if [ -z "$CXX" ]; then
     CXX=g++
 fi
-# We may set CPP, FC, F77 (to sage_fortran?) etc. here as well;
-# letting at least CPP have a default value ('cpp') probably makes sense.
+if [ -z "$FC" ]; then
+    if [ -n "$SAGE_FORTRAN" ]; then
+        # Deprecated, see #13349.
+        FC="$SAGE_FORTRAN"
+    elif command -v gfortran >/dev/null 2>/dev/null; then
+        FC=gfortran
+    elif command -v g95 >/dev/null 2>/dev/null; then
+        FC=g95
+    elif command -v g77 >/dev/null 2>/dev/null; then
+        FC=g77
+    fi
+fi
 
 # An Objective-C compiler is needed for R on Darwin.
 # On Darwin, /usr/bin/cc supports Objective-C.  The gcc shipped with
@@ -458,9 +468,7 @@ if [ "$UNAME" = "Darwin" ]; then
     fi
 fi
 
-# Override CC, CPP, CXX, FC, F77 and F95 if the GCC spkg was installed:
-# (We *may* also just unset FC/F77/F95 in case $SAGE_LOCAL/bin/gfortran is
-# present.)
+# Override CC, CPP, CXX, FC if the GCC spkg was installed.
 if [ -x "$SAGE_LOCAL/bin/gcc" ]; then
     CC=gcc
 fi
@@ -470,12 +478,15 @@ fi
 if [ -x "$SAGE_LOCAL/bin/g++" ]; then
     CXX=g++
 fi
-export CC CPP CXX
 if [ -x "$SAGE_LOCAL/bin/gfortran" ]; then
-    for var in FC F77 F95; do
-        export ${var}=gfortran
-    done
+    FC=gfortran
 fi
+export CC CPP CXX FC
+
+# Set other Fortran-related compiler variables
+export F77="$FC"
+export F90="$FC"   # Needed for SciPy
+export F95="$FC"
 
 # Setup env varariables if ccache is installed
 if [ -d "$SAGE_LOCAL/libexec/ccache" ]; then


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13992">trac #13992</a>.

Reported by: jdemeyer

Component: build

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: François Bissey

Merged in: sage-5.7.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13992/13992_fortran_env.patch">13992_fortran_env.patch: </a> by jdemeyer at 20130123T08:28:09</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13992/13992_inline_fortran.patch">13992_inline_fortran.patch: </a> by jdemeyer at 20130123T10:48:47</li></ol>
