### PR TITLE
Remove zodb from sage

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -94,7 +94,6 @@ twisted                              Custom (Modified BSD)
 twistedweb2                          MIT Free Software licence
 weave                                SciPy License (=Modified BSD)
 zlib                                 Custom (Modified BSD)
-zodb3                                ZPL
 
 CONTACT INFO:
      William Stein; wstein@gmail.com;
@@ -1501,52 +1500,5 @@ Copyright (C) 1995-2004 Jean-loup Gailly and Mark Adler
 
   Jean-loup Gailly jloup@gzip.org
   Mark Adler madler@alumni.caltech.edu
-
-================================================================================
-
-zodb3
-:
-(http://www.zope.org/Wikis/ZODB/)
-Zope Public License
-
-This is GPL compatible according to
-   http://www.fsf.org/licensing/licenses/index_html#GPLCompatibleLicenses
-
-Zope is made available under the Zope Public License. This license seeks
-to allow free use of Zope and its source given a few conditions for use.
-
-Our goals are to allow Zope to flourish as an open source project while
-making sure that we get some credit for having originally developed Zope.
-
-The 2.1 version of the license is reusable. It supports having a consistent
-license for Zope and third-party products without requiring 3rd-party
-developers to assign copyright to Zope Corporation.
-
-It is important that add-on products for Zope be released under the ZPL.
-Why? Two reasons:
-
-* The ZPL is a flexible license that supports both commercial and
-  non-commercial use of the software.
-* If Zope add-on products are released under the ZPL, then users of
-  Zope and the add-on products only have one license to worry about.
-  Keeping track of many different licenses is a burden to users.
-
-Software can be released under multiple licenses. For example, software
-can be released under both the ZPL and the GPL.
-
-We will update the Zope software to use ZPL 2.1. This does not change the
-rules for contributing to the Zope software repository. Contributions to the
-Zope repository will still be owned by "Zope Corporation and Contributors".
-
-To use the ZPL 2.1 license, just include the license with your software
-and also include a separate copyright statement (sample).
-
-We have updated to the 2.1 version. The license though, like Zope itself,
-is a work-in-progress. We would love to hear your ideas on the license.
-Please send your comments on the license to legal@zope.com.
-
-This license has received OSD branding. Zope Corporation is working to
-stay true to the spirit of the Open Source Definition and its stated
-rationales. This license has been confirmed as GPL compatible by the FSF.
 
 ================================================================================

--- a/build/install
+++ b/build/install
@@ -442,7 +442,6 @@ TACHYON=`newest_version tachyon`
 TERMCAP=`newest_version termcap`
 ZLIB=`newest_version zlib`
 ZNPOLY=`newest_version zn_poly`
-ZODB=`newest_version zodb3`
 
 EOF
 

--- a/build/standard/deps
+++ b/build/standard/deps
@@ -117,8 +117,7 @@ all-sage: \
      $(INST)/$(TACHYON) \
      $(INST)/$(TERMCAP) \
      $(INST)/$(ZLIB) \
-     $(INST)/$(ZNPOLY) \
-     $(INST)/$(ZODB)
+     $(INST)/$(ZNPOLY)
 
 # TOOLCHAIN consists of dependencies determined by spkg/install
 toolchain: $(TOOLCHAIN)
@@ -445,9 +444,6 @@ $(INST)/$(JINJA2): $(INST)/$(PYTHON) $(INST)/$(SETUPTOOLS) $(INST)/$(DOCUTILS) \
 $(INST)/$(PYGMENTS): $(INST)/$(PYTHON) $(INST)/$(SETUPTOOLS)
 	+$(PIPE) "$(SAGE_SPKG) $(PYGMENTS) 2>&1" "tee -a $(SAGE_LOGS)/$(PYGMENTS).log"
 
-$(INST)/$(ZODB): $(INST)/$(PYTHON) $(INST)/$(SETUPTOOLS)
-	+$(PIPE) "$(SAGE_SPKG) $(ZODB) 2>&1" "tee -a $(SAGE_LOGS)/$(ZODB).log"
-
 # List all *build-time* dependencies of the Sage library.  These are,
 # on the one hand, programs needed for the build/install process of the
 # Sage library (e.g. SAGE_SCRIPTS, SCONS, MERCURIAL, JINJA2), and on the
@@ -544,7 +540,6 @@ $(INST)/$(CEPHES):
 # setuptools forgets to update easy-install.pth during parallel
 # builds, so we build the relevant packages serially.
 
-$(INST)/$(SQLALCHEMY): $(INST)/$(ZODB)
 $(INST)/$(PYGMENTS): $(INST)/$(SQLALCHEMY)
 $(INST)/$(JINJA2): $(INST)/$(PYGMENTS)
 $(INST)/$(SPHINX): $(INST)/$(JINJA2)


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/10353">trac #10353</a>.

remeve reference to zodb in sage_root

Reported by: was

Component: misc

CC: kini

Report Upstream: N/A

Authors: François Bissey

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12205">trac #12205</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/13717">trac #13717</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/13963">trac #13963</a>

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.7.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/10353/trac10353-db-removal.patch">trac10353-db-removal.patch: this patch remove reference to zodb from the sage library</a> by fbissey at 20130104T10:16:48</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/10353/trac10353-sage_root.patch">trac10353-sage_root.patch: remeve reference to zodb in sage_root</a> by fbissey at 20130107T10:07:29</li></ol>
