### PR TITLE
Support GCC version "4.7" in LinBox

### DIFF
--- a/build/pkgs/linbox/SPKG.txt
+++ b/build/pkgs/linbox/SPKG.txt
@@ -37,6 +37,10 @@ LGPL V2 or later
 
 == Changelog ==
 
+=== linbox-1.1.6.p11 (Jeroen Demeyer, 19 June 2012) ===
+ * #13118: Don't look at compiler versions, just use the -fpermissive
+   flag whenever the compiler supports it.
+
 === linbox-1.1.6.p10 (Jeroen Demeyer, 25 May 2012) ===
  * #12762 review: Remove the touching of linbox.pyx, since
    Cython knows the dependency of linbox.pyx on linbox-sage.h

--- a/build/pkgs/linbox/spkg-install
+++ b/build/pkgs/linbox/spkg-install
@@ -29,12 +29,11 @@ done
 CFLAGS="-g $CFLAGS -fPIC"
 CXXFLAGS="-g $CXXFLAGS -fPIC"
 
-case "`testcxx.sh $CXX`-`$CXX -dumpversion 2>/dev/null`" in
-    GCC-4.7.*)
-        echo "Adding '-fpermissive' to CXXFLAGS to make LinBox build with GCC 4.7.x."
-        echo "This is a temporary fix; LinBox currently doesn't conform to the C++11 standard."
-        CXXFLAGS="-fpermissive $CXXFLAGS" # The user might still override that.
-esac
+# Add -fpermissive flag if the C++ compiler supports it.
+# This is needed to make LinBox build with GCC 4.7.x, because it
+# doesn't fully conform to the C++11 standard.
+# On older GCC versions, it doesn't hurt.
+CXXFLAGS="`CC=$CXX testcflags.sh -fpermissive` $CXXFLAGS"
 
 # Some systems have problems when parts of LinBox are compiled with
 # the commentator enabled and other parts with the commentator


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13118">trac #13118</a>.

linbox error on rackspace.com virtual machine, ubuntu 12

Reported by: jdemeyer

Component: packages

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: R. Andrew Ohana

Merged in: sage-5.1.beta6

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13118/linbox-1.1.6.p11.diff">linbox-1.1.6.p11.diff: Diff for the linbox spkg. For reference / review only.</a> by jdemeyer at 20120618T22:34:01</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13118/here.txt">here.txt: linbox error on rackspace.com virtual machine, ubuntu 12</a> by startakovsky at 20121029T22:47:28</li></ol>
