### PR TITLE
update M4RIE to newest upstream release

### DIFF
--- a/build/pkgs/libm4rie/SPKG.txt
+++ b/build/pkgs/libm4rie/SPKG.txt
@@ -30,10 +30,9 @@ GF(2^k) for 2 <= k <= 10.
 
 == Releases/Changelog ==
 
-=== libm4rie-20120415 (Martin Albrecht, 13 April 2012) ===
+=== libm4rie-20120613 (Martin Albrecht, 7 June 2012) ===
  * #12841: new upstream release
  * delete old headers before installing new ones
- * _ap_pend -O0 if SAGE_DEBUG="yes", to make sure we overwrite whatever CFLAGS has
 
 === libm4rie-20111004.p3 (Jeroen Demeyer, 10 April 2012) ===
  * Trac #12821: don't quote $CC when running testcc.sh


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12841">trac #12841</a>.

Reported by: malb

Component: packages

CC: 

Report Upstream: N/A

Authors: Martin Albrecht

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12840">trac #12840</a>

Work issues: 

Reviewers: Simon King, Jeroen Demeyer, Volker Braun

Merged in: sage-5.3.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12841/trac_12841_m4rie_new_version.patch">trac_12841_m4rie_new_version.patch: </a> by malb at 20120413T19:43:40</li></ol>
