### PR TITLE
Many doctest options are undocumented

### DIFF
--- a/src/doc/en/developer/conventions.rst
+++ b/src/doc/en/developer/conventions.rst
@@ -727,7 +727,7 @@ the example.
 Further conventions for automated testing of examples
 -----------------------------------------------------
 
-The Python script ``SAGE_LOCAL/bin/sage-doctest`` implements
+The Python script ``SAGE_LOCAL/bin/sage-runtests`` implements
 documentation testing in Sage (see :ref:`chapter-testing` for more
 details). When writing documentation, keep the following points in
 mind:
@@ -746,7 +746,7 @@ mind:
        sage: plot(x^2 - 5, (x, 0, 5), ymin=0).save(tmp_filename(ext='.png'))
 
 -  If a test line contains the text ``random``, it is executed by
-   ``sage-doctest`` but ``sage-doctest`` does not check that the
+   ``sage-runtests`` but ``sage-runtests`` does not check that the
    output agrees with the output in the documentation string. For
    example, the docstring for the ``__hash__`` method for
    ``CombinatorialObject`` in
@@ -838,9 +838,9 @@ mind:
        sage: p.roots(multiplicities=False)[2]     # relative tol 1e-10
        10000000000000000
 
--  If a line contains ``not implemented``, it is never
-   tested. It is good to include lines like this to make clear what we
-   want Sage to eventually implement::
+-  If a line contains ``not implemented`` or ``not tested``, it is
+   never tested. It is good to include lines like this to make clear
+   what we want Sage to eventually implement::
 
        sage: factor(x*y - x*z)    # todo: not implemented
 
@@ -904,6 +904,39 @@ Using ``search_src`` from the Sage prompt (or ``grep``), one can
 easily find the aforementioned keywords. In the case of
 ``todo: not implemented``, one can use the results of such a search to
 direct further development on Sage.
+
+- Some tests (hashing for example) behave differently on 32-bit and
+  64-bit platforms.  You can mark a line (generally the output) with
+  either ``# 32-bit`` or ``# 64-bit`` and the testing framework will
+  remove any lines that don't match the current architecture.  For
+  example::
+
+      sage: z = 32
+      sage: z.powermodm_ui(2^32-1, 14)
+      Traceback (most recent call last):                              # 32-bit
+      ...                                                             # 32-bit
+      OverflowError: exp (=4294967295) must be <= 4294967294          # 32-bit
+      8              # 64-bit
+
+- You may write tests that span multiple lines.  The best way to do so
+  is to use the line continuation marker ``....:``. ::
+
+      sage: for n in srange(1,10):
+      ....:     if n.is_prime():
+      ....:         print n,
+      2 3 5 7
+
+  If you have a long line of code, you may want to consider adding a
+  backslash to the end of the line, which tells the doctesting
+  framework to join that current line with the next.  This syntax is
+  non-standard so may be removed in a future version of Sage, but in
+  the mean time it can be useful for breaking up large integers across
+  multiple lines::
+
+      sage: n = 123456789123456789123456789\
+      ....:     123456789123456789123456789
+      sage: n.is_prime()
+      False
 
 .. _chapter-testing:
 

--- a/src/doc/en/developer/doctesting.rst
+++ b/src/doc/en/developer/doctesting.rst
@@ -69,15 +69,6 @@ module. Notice that the syntax is ::
     All tests passed!
     ------------------------------------------------------------------------
     Total time for all tests: 4.9 seconds
-    [jdemeyer@sage sage-5.9]$ ./sage -t "devel/sage-main/sage/games/sudoku.py
-    Running doctests with ID 2012-07-03-03-39-02-da6accbb.
-    Doctesting 1 file.
-    sage -t devel/sage-main/sage/games/sudoku.py
-        [103 tests, 3.6 s]
-    ------------------------------------------------------------------------
-    All tests passed!
-    ------------------------------------------------------------------------
-    Total time for all tests: 4.9 seconds
         cpu time: 3.6 seconds
         cumulative wall time: 3.6 seconds
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12281">trac #12281</a>.

Reported by: mjo

Component: documentation

CC: kcrisman

Report Upstream: N/A

Authors: David Roe

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12415">trac #12415</a>

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12281/12281.patch">12281.patch: </a> by roed at 20130315T00:17:57</li></ol>
