### PR TITLE
Doctest debugger doesn't work on OS X

### DIFF
--- a/src/sage/doctest/forker.py
+++ b/src/sage/doctest/forker.py
@@ -77,6 +77,10 @@ def init_sage():
     import sage.misc.displayhook
     sys.displayhook = sage.misc.displayhook.DisplayHook(sys.displayhook)
 
+    # We import readline before forking, otherwise Pdb doesn't work
+    # os OS X: http://trac.sagemath.org/sage_trac/ticket/14289
+    import readline
+
     # Workarounds for https://github.com/sagemath/sagenb/pull/84
     import sagenb.notebook.misc
     import sagenb.notebook.sage_email


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14289">trac #14289</a>.

Reported by: roed

Component: doctest

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12415">trac #12415</a>

Work issues: 

Reviewers: David Roe

Merged in: sage-5.9.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14289/14289_doctest_readline.patch">14289_doctest_readline.patch: </a> by jdemeyer at 20130318T07:34:42</li></ol>
