### PR TITLE
MPIR fails to build when CPU's architecture name doesn't match its actual capabilities

### DIFF
--- a/build/pkgs/mpir/SPKG.txt
+++ b/build/pkgs/mpir/SPKG.txt
@@ -54,8 +54,18 @@ See http://www.mpir.org
    bail out with an error when encountering "define(,1)".
    These files were patched using
      find mpn -name '*.asm' -exec sed -i 's/define(\(OPERATION[^,]*\),/define(\`\1'"'"',/' {} \;
+ * configure.patch: add some extra run-time configure tests, remove
+   mentions of Fortran. Re-generated configure (using the same versions
+   of autoconf, automake and libtool as the original files).
 
 == Changelog ==
+
+=== mpir-2.4.0.p5 (Jeroen Demeyer, 27 May 2012) ===
+ * Trac #12970: configure.patch: add some configure tests to check that
+   certain code compiles and runs. In particular, add a runtime test
+   for unsigned long/double division.
+ * Additionally, remove all mentions of Fortran in the configure file.
+   Supposedly, it was there to work around a libtool bug.
 
 === mpir-2.4.0.p4 (Jeroen Demeyer, 26 May 2012) ===
  * Trac #12954: when SAGE_FAT_BINARY=yes on systems which don't support

--- a/build/pkgs/mpir/patches/configure.patch
+++ b/build/pkgs/mpir/patches/configure.patch
@@ -1,0 +1,4267 @@
+diff -dru src/acinclude.m4 b/acinclude.m4
+--- src/acinclude.m4	2011-04-27 03:43:23.000000000 -0700
++++ b/acinclude.m4	2012-05-27 21:43:11.000000000 -0700
+@@ -515,31 +515,45 @@
+ int cmov () { return (n >= 0 ? n : 0); }
+ ])
+ 
+-GMP_PROG_CC_WORKS_PART([$1], [double -> ulong conversion],
++GMP_PROG_CC_WORKS_PART_MAIN([$1], [double -> ulong conversion],
+ [/* The following provokes a linker invocation problem with gcc 3.0.3
+    on AIX 4.3 under "-maix64 -mpowerpc64 -mcpu=630".  The -mcpu=630
+    option causes gcc to incorrectly select the 32-bit libgcc.a, not
+    the 64-bit one, and consequently it misses out on the __fixunsdfdi
+-   helper (double -> uint64 conversion).  */
+-double d;
+-unsigned long gcc303 () { return (unsigned long) d; }
++   helper (double -> uint64 conversion).
++   This also provokers errors on x86 when AVX instructions are
++   generated but not understood by the assembler or processor.*/
++volatile double d;
++volatile unsigned long u;
++int main() { d = 0.1; u = (unsigned long)d; return (int)u; }
+ ])
+ 
+-GMP_PROG_CC_WORKS_PART([$1], [double negation],
++GMP_PROG_CC_WORKS_PART_MAIN([$1], [double negation],
+ [/* The following provokes an error from hppa gcc 2.95 under -mpa-risc-2-0 if
+    the assembler doesn't know hppa 2.0 instructions.  fneg is a 2.0
+    instruction, and a negation like this comes out using it.  */
+-double fneg_data;
+-unsigned long fneg () { return -fneg_data; }
++volatile double d;
++volatile double d2;
++int main() { d = -0.1; d2 = -d; return (int)d2; }
+ ])
+ 
+-GMP_PROG_CC_WORKS_PART([$1], [double -> float conversion],
++GMP_PROG_CC_WORKS_PART_MAIN([$1], [double -> float conversion],
+ [/* The following makes gcc 3.3 -march=pentium4 generate an SSE2 xmm insn
+    (cvtsd2ss) which will provoke an error if the assembler doesn't recognise
+    those instructions.  Not sure how much of the gmp code will come out
+    wanting sse2, but it's easiest to reject an option we know is bad.  */
+-double ftod_data;
+-float ftod () { return (float) ftod_data; }
++volatile double d;
++volatile float f;
++int main() { d = 0.1; f = (float)d; return (int)f; }
++])
++
++GMP_PROG_CC_WORKS_PART_MAIN([$1], [unsigned long/double division],
++[/* The following generates a vmovd instruction on Sandy Bridge.
++   Check that the assembler knows this instruction. */
++volatile unsigned long a;
++volatile double b;
++int main()
++{ a = 1; b = 3; return (int)(a/b); }
+ ])
+ 
+ # __builtin_alloca is not available everywhere, check it exists before
+diff -dru src/configure.in b/configure.in
+--- src/configure.in	2011-05-27 23:09:15.000000000 -0700
++++ b/configure.in	2012-05-18 14:59:37.000000000 -0700
+@@ -2009,16 +2009,6 @@
+   fi
+ fi
+ 
+-# The dead hand of AC_REQUIRE makes AC_PROG_LIBTOOL expand and execute
+-# AC_PROG_F77, even when F77 is not in the selected with_tags.  This is
+-# probably harmless, but it's unsightly and bloats our configure, so pretend
+-# AC_PROG_F77 has been expanded already.
+-#
+-# FIXME: Rumour has it libtool will one day provide a way for a configure.in
+-# to say what it wants from among supported languages etc.
+-#
+-AC_PROVIDE([AC_PROG_F77])
+-
+ AC_PROG_LIBTOOL
+ 
+ # Generate an error here if attempting to build both shared and static when
+diff -dru src/yasm/Makefile.in b/yasm/Makefile.in
+--- src/yasm/Makefile.in	2011-06-13 22:35:39.000000000 -0700
++++ b/yasm/Makefile.in	2012-05-18 14:35:01.000000000 -0700
+@@ -3868,7 +3868,8 @@
+ check-am: all-am
+ 	$(MAKE) $(AM_MAKEFLAGS) $(check_PROGRAMS)
+ 	$(MAKE) $(AM_MAKEFLAGS) check-TESTS
+-check:
++check: $(BUILT_SOURCES)
++	$(MAKE) $(AM_MAKEFLAGS) check-recursive
+ all-am: Makefile $(LIBRARIES) $(PROGRAMS) $(MANS) $(HEADERS) config.h \
+ 		all-local
+ installdirs: installdirs-recursive
+@@ -3876,7 +3877,8 @@
+ 	for dir in "$(DESTDIR)$(libdir)" "$(DESTDIR)$(bindir)" "$(DESTDIR)$(man1dir)" "$(DESTDIR)$(man7dir)" "$(DESTDIR)$(includedir)" "$(DESTDIR)$(modincludedir)" "$(DESTDIR)$(includedir)"; do \
+ 	  test -z "$$dir" || $(MKDIR_P) "$$dir"; \
+ 	done
+-install:
++install: $(BUILT_SOURCES)
++	$(MAKE) $(AM_MAKEFLAGS) install-recursive
+ install-exec: install-exec-recursive
+ install-data: install-data-recursive
+ uninstall: uninstall-recursive
+diff -dru src/configure b/configure
+--- src/configure	2011-06-13 22:34:01.000000000 -0700
++++ b/configure	2012-05-27 21:54:57.000000000 -0700
+@@ -2071,52 +2071,6 @@
+ 
+ } # ac_fn_cxx_try_link
+ 
+-# ac_fn_f77_try_link LINENO
+-# -------------------------
+-# Try to link conftest.$ac_ext, and return whether this succeeded.
+-ac_fn_f77_try_link ()
+-{
+-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+-  rm -f conftest.$ac_objext conftest$ac_exeext
+-  if { { ac_try="$ac_link"
+-case "(($ac_try" in
+-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+-  *) ac_try_echo=$ac_try;;
+-esac
+-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+-$as_echo "$ac_try_echo"; } >&5
+-  (eval "$ac_link") 2>conftest.err
+-  ac_status=$?
+-  if test -s conftest.err; then
+-    grep -v '^ *+' conftest.err >conftest.er1
+-    cat conftest.er1 >&5
+-    mv -f conftest.er1 conftest.err
+-  fi
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; } && {
+-	 test -z "$ac_f77_werror_flag" ||
+-	 test ! -s conftest.err
+-       } && test -s conftest$ac_exeext && {
+-	 test "$cross_compiling" = yes ||
+-	 $as_test_x conftest$ac_exeext
+-       }; then :
+-  ac_retval=0
+-else
+-  $as_echo "$as_me: failed program was:" >&5
+-sed 's/^/| /' conftest.$ac_ext >&5
+-
+-	ac_retval=1
+-fi
+-  # Delete the IPA/IPO (Inter Procedural Analysis/Optimization) information
+-  # created by the PGI compiler (conftest_ipa8_conftest.oo), as it would
+-  # interfere with the next link command; also delete a directory that is
+-  # left behind by Apple's compiler.  We do this before executing the actions.
+-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
+-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+-  as_fn_set_status $ac_retval
+-
+-} # ac_fn_f77_try_link
+-
+ # ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
+ # ---------------------------------------------
+ # Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
+@@ -5363,11 +5317,13 @@
+    on AIX 4.3 under "-maix64 -mpowerpc64 -mcpu=630".  The -mcpu=630
+    option causes gcc to incorrectly select the 32-bit libgcc.a, not
+    the 64-bit one, and consequently it misses out on the __fixunsdfdi
+-   helper (double -> uint64 conversion).  */
+-double d;
+-unsigned long gcc303 () { return (unsigned long) d; }
++   helper (double -> uint64 conversion).
++   This also provokers errors on x86 when AVX instructions are
++   generated but not understood by the assembler or processor.*/
++volatile double d;
++volatile unsigned long u;
++int main() { d = 0.1; u = (unsigned long)d; return (int)u; }
+ 
+-int main () { return 0; }
+ EOF
+   echo "Test compile: double -> ulong conversion" >&5
+   gmp_compile="$cc $cflags $cppflags conftest.c >&5"
+@@ -5411,7 +5367,6 @@
+ 
+ 
+ 
+-
+ if test "$gmp_prog_cc_works" = yes; then
+   # remove anything that might look like compiler output to our "||" expression
+   rm -f conftest* a.out b.out a.exe a_out.exe
+@@ -5419,10 +5374,10 @@
+ /* The following provokes an error from hppa gcc 2.95 under -mpa-risc-2-0 if
+    the assembler doesn't know hppa 2.0 instructions.  fneg is a 2.0
+    instruction, and a negation like this comes out using it.  */
+-double fneg_data;
+-unsigned long fneg () { return -fneg_data; }
++volatile double d;
++volatile double d2;
++int main() { d = -0.1; d2 = -d; return (int)d2; }
+ 
+-int main () { return 0; }
+ EOF
+   echo "Test compile: double negation" >&5
+   gmp_compile="$cc $cflags $cppflags conftest.c >&5"
+@@ -5466,7 +5421,6 @@
+ 
+ 
+ 
+-
+ if test "$gmp_prog_cc_works" = yes; then
+   # remove anything that might look like compiler output to our "||" expression
+   rm -f conftest* a.out b.out a.exe a_out.exe
+@@ -5475,10 +5429,10 @@
+    (cvtsd2ss) which will provoke an error if the assembler doesn't recognise
+    those instructions.  Not sure how much of the gmp code will come out
+    wanting sse2, but it's easiest to reject an option we know is bad.  */
+-double ftod_data;
+-float ftod () { return (float) ftod_data; }
++volatile double d;
++volatile float f;
++int main() { d = 0.1; f = (float)d; return (int)f; }
+ 
+-int main () { return 0; }
+ EOF
+   echo "Test compile: double -> float conversion" >&5
+   gmp_compile="$cc $cflags $cppflags conftest.c >&5"
+@@ -5522,6 +5476,59 @@
+ 
+ 
+ 
++if test "$gmp_prog_cc_works" = yes; then
++  # remove anything that might look like compiler output to our "||" expression
++  rm -f conftest* a.out b.out a.exe a_out.exe
++  cat >conftest.c <<EOF
++/* The following generates a vmovd instruction on Sandy Bridge.
++   Check that the assembler knows this instruction. */
++volatile unsigned long a;
++volatile double b;
++int main()
++{ a = 1; b = 3; return (int)(a/b); }
++
++EOF
++  echo "Test compile: unsigned long/double division" >&5
++  gmp_compile="$cc $cflags $cppflags conftest.c >&5"
++  if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
++  (eval $gmp_compile) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++    cc_works_part=yes
++    if test "$cross_compiling" = no; then
++      if { ac_try='./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest'
++  { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_try\""; } >&5
++  (eval $ac_try) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }; then :;
++      else
++        cc_works_part=norun
++      fi
++    fi
++  else
++    cc_works_part=no
++  fi
++  if test "$cc_works_part" != yes; then
++    echo "failed program was:" >&5
++    cat conftest.c >&5
++  fi
++  rm -f conftest* a.out b.out a.exe a_out.exe
++  case $cc_works_part in
++    yes)
++
++      ;;
++    no)
++      gmp_prog_cc_works="no, unsigned long/double division"
++      ;;
++    norun)
++      gmp_prog_cc_works="no, unsigned long/double division, program does not run"
++      ;;
++  esac
++fi
++
++
+ 
+ # __builtin_alloca is not available everywhere, check it exists before
+ # seeing that it works
+@@ -6644,11 +6651,13 @@
+    on AIX 4.3 under "-maix64 -mpowerpc64 -mcpu=630".  The -mcpu=630
+    option causes gcc to incorrectly select the 32-bit libgcc.a, not
+    the 64-bit one, and consequently it misses out on the __fixunsdfdi
+-   helper (double -> uint64 conversion).  */
+-double d;
+-unsigned long gcc303 () { return (unsigned long) d; }
++   helper (double -> uint64 conversion).
++   This also provokers errors on x86 when AVX instructions are
++   generated but not understood by the assembler or processor.*/
++volatile double d;
++volatile unsigned long u;
++int main() { d = 0.1; u = (unsigned long)d; return (int)u; }
+ 
+-int main () { return 0; }
+ EOF
+   echo "Test compile: double -> ulong conversion" >&5
+   gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
+@@ -6692,7 +6701,6 @@
+ 
+ 
+ 
+-
+ if test "$gmp_prog_cc_works" = yes; then
+   # remove anything that might look like compiler output to our "||" expression
+   rm -f conftest* a.out b.out a.exe a_out.exe
+@@ -6700,10 +6708,10 @@
+ /* The following provokes an error from hppa gcc 2.95 under -mpa-risc-2-0 if
+    the assembler doesn't know hppa 2.0 instructions.  fneg is a 2.0
+    instruction, and a negation like this comes out using it.  */
+-double fneg_data;
+-unsigned long fneg () { return -fneg_data; }
++volatile double d;
++volatile double d2;
++int main() { d = -0.1; d2 = -d; return (int)d2; }
+ 
+-int main () { return 0; }
+ EOF
+   echo "Test compile: double negation" >&5
+   gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
+@@ -6747,7 +6755,6 @@
+ 
+ 
+ 
+-
+ if test "$gmp_prog_cc_works" = yes; then
+   # remove anything that might look like compiler output to our "||" expression
+   rm -f conftest* a.out b.out a.exe a_out.exe
+@@ -6756,10 +6763,10 @@
+    (cvtsd2ss) which will provoke an error if the assembler doesn't recognise
+    those instructions.  Not sure how much of the gmp code will come out
+    wanting sse2, but it's easiest to reject an option we know is bad.  */
+-double ftod_data;
+-float ftod () { return (float) ftod_data; }
++volatile double d;
++volatile float f;
++int main() { d = 0.1; f = (float)d; return (int)f; }
+ 
+-int main () { return 0; }
+ EOF
+   echo "Test compile: double -> float conversion" >&5
+   gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
+@@ -6803,6 +6810,59 @@
+ 
+ 
+ 
++if test "$gmp_prog_cc_works" = yes; then
++  # remove anything that might look like compiler output to our "||" expression
++  rm -f conftest* a.out b.out a.exe a_out.exe
++  cat >conftest.c <<EOF
++/* The following generates a vmovd instruction on Sandy Bridge.
++   Check that the assembler knows this instruction. */
++volatile unsigned long a;
++volatile double b;
++int main()
++{ a = 1; b = 3; return (int)(a/b); }
++
++EOF
++  echo "Test compile: unsigned long/double division" >&5
++  gmp_compile="$cc $cflags $cppflags $flag conftest.c >&5"
++  if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$gmp_compile\""; } >&5
++  (eval $gmp_compile) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; then
++    cc_works_part=yes
++    if test "$cross_compiling" = no; then
++      if { ac_try='./a.out || ./b.out || ./a.exe || ./a_out.exe || ./conftest'
++  { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_try\""; } >&5
++  (eval $ac_try) 2>&5
++  ac_status=$?
++  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
++  test $ac_status = 0; }; }; then :;
++      else
++        cc_works_part=norun
++      fi
++    fi
++  else
++    cc_works_part=no
++  fi
++  if test "$cc_works_part" != yes; then
++    echo "failed program was:" >&5
++    cat conftest.c >&5
++  fi
++  rm -f conftest* a.out b.out a.exe a_out.exe
++  case $cc_works_part in
++    yes)
++
++      ;;
++    no)
++      gmp_prog_cc_works="no, unsigned long/double division"
++      ;;
++    norun)
++      gmp_prog_cc_works="no, unsigned long/double division, program does not run"
++      ;;
++  esac
++fi
++
++
+ 
+ # __builtin_alloca is not available everywhere, check it exists before
+ # seeing that it works
+@@ -11761,16 +11821,6 @@
+   fi
+ fi
+ 
+-# The dead hand of AC_REQUIRE makes AC_PROG_LIBTOOL expand and execute
+-# AC_PROG_F77, even when F77 is not in the selected with_tags.  This is
+-# probably harmless, but it's unsightly and bloats our configure, so pretend
+-# AC_PROG_F77 has been expanded already.
+-#
+-# FIXME: Rumour has it libtool will one day provide a way for a configure.in
+-# to say what it wants from among supported languages etc.
+-#
+-
+-
+ case `pwd` in
+   *\ * | *\	*)
+     { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Libtool does not cope well with whitespace in \`pwd\`" >&5
+@@ -14654,7 +14704,6 @@
+ 
+ 
+ 
+-
+ # Set options
+ 
+ 
+@@ -21800,2717 +21849,6 @@
+ 
+ 
+ 
+-      ac_ext=f
+-ac_compile='$F77 -c $FFLAGS conftest.$ac_ext >&5'
+-ac_link='$F77 -o conftest$ac_exeext $FFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_f77_compiler_gnu
+-
+-if test -z "$F77" || test "X$F77" = "Xno"; then
+-  _lt_disable_F77=yes
+-fi
+-
+-archive_cmds_need_lc_F77=no
+-allow_undefined_flag_F77=
+-always_export_symbols_F77=no
+-archive_expsym_cmds_F77=
+-export_dynamic_flag_spec_F77=
+-hardcode_direct_F77=no
+-hardcode_direct_absolute_F77=no
+-hardcode_libdir_flag_spec_F77=
+-hardcode_libdir_flag_spec_ld_F77=
+-hardcode_libdir_separator_F77=
+-hardcode_minus_L_F77=no
+-hardcode_automatic_F77=no
+-inherit_rpath_F77=no
+-module_cmds_F77=
+-module_expsym_cmds_F77=
+-link_all_deplibs_F77=unknown
+-old_archive_cmds_F77=$old_archive_cmds
+-reload_flag_F77=$reload_flag
+-reload_cmds_F77=$reload_cmds
+-no_undefined_flag_F77=
+-whole_archive_flag_spec_F77=
+-enable_shared_with_static_runtimes_F77=no
+-
+-# Source file extension for f77 test sources.
+-ac_ext=f
+-
+-# Object file extension for compiled f77 test sources.
+-objext=o
+-objext_F77=$objext
+-
+-# No sense in running all these tests if we already determined that
+-# the F77 compiler isn't working.  Some variables (like enable_shared)
+-# are currently assumed to apply to all compilers on this platform,
+-# and will be corrupted by setting them based on a non-working compiler.
+-if test "$_lt_disable_F77" != yes; then
+-  # Code to be used in simple compile tests
+-  lt_simple_compile_test_code="\
+-      subroutine t
+-      return
+-      end
+-"
+-
+-  # Code to be used in simple link tests
+-  lt_simple_link_test_code="\
+-      program t
+-      end
+-"
+-
+-  # ltmain only uses $CC for tagged configurations so make sure $CC is set.
+-
+-
+-
+-
+-
+-
+-# If no C compiler was specified, use CC.
+-LTCC=${LTCC-"$CC"}
+-
+-# If no C compiler flags were specified, use CFLAGS.
+-LTCFLAGS=${LTCFLAGS-"$CFLAGS"}
+-
+-# Allow CC to be a program name with arguments.
+-compiler=$CC
+-
+-
+-  # save warnings/boilerplate of simple test code
+-  ac_outfile=conftest.$ac_objext
+-echo "$lt_simple_compile_test_code" >conftest.$ac_ext
+-eval "$ac_compile" 2>&1 >/dev/null | $SED '/^$/d; /^ *+/d' >conftest.err
+-_lt_compiler_boilerplate=`cat conftest.err`
+-$RM conftest*
+-
+-  ac_outfile=conftest.$ac_objext
+-echo "$lt_simple_link_test_code" >conftest.$ac_ext
+-eval "$ac_link" 2>&1 >/dev/null | $SED '/^$/d; /^ *+/d' >conftest.err
+-_lt_linker_boilerplate=`cat conftest.err`
+-$RM -r conftest*
+-
+-
+-  # Allow CC to be a program name with arguments.
+-  lt_save_CC="$CC"
+-  lt_save_GCC=$GCC
+-  lt_save_CFLAGS=$CFLAGS
+-  CC=${F77-"f77"}
+-  CFLAGS=$FFLAGS
+-  compiler=$CC
+-  compiler_F77=$CC
+-  for cc_temp in $compiler""; do
+-  case $cc_temp in
+-    compile | *[\\/]compile | ccache | *[\\/]ccache ) ;;
+-    distcc | *[\\/]distcc | purify | *[\\/]purify ) ;;
+-    \-*) ;;
+-    *) break;;
+-  esac
+-done
+-cc_basename=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
+-
+-  GCC=$G77
+-  if test -n "$compiler"; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if libtool supports shared libraries" >&5
+-$as_echo_n "checking if libtool supports shared libraries... " >&6; }
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $can_build_shared" >&5
+-$as_echo "$can_build_shared" >&6; }
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build shared libraries" >&5
+-$as_echo_n "checking whether to build shared libraries... " >&6; }
+-    test "$can_build_shared" = "no" && enable_shared=no
+-
+-    # On AIX, shared libraries and static libraries use the same namespace, and
+-    # are all built from PIC.
+-    case $host_os in
+-      aix3*)
+-        test "$enable_shared" = yes && enable_static=no
+-        if test -n "$RANLIB"; then
+-          archive_cmds="$archive_cmds~\$RANLIB \$lib"
+-          postinstall_cmds='$RANLIB $lib'
+-        fi
+-        ;;
+-      aix[4-9]*)
+-	if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
+-	  test "$enable_shared" = yes && enable_static=no
+-	fi
+-        ;;
+-    esac
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_shared" >&5
+-$as_echo "$enable_shared" >&6; }
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build static libraries" >&5
+-$as_echo_n "checking whether to build static libraries... " >&6; }
+-    # Make sure either enable_shared or enable_static is yes.
+-    test "$enable_shared" = yes || enable_static=yes
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_static" >&5
+-$as_echo "$enable_static" >&6; }
+-
+-    GCC_F77="$G77"
+-    LD_F77="$LD"
+-
+-    ## CAVEAT EMPTOR:
+-    ## There is no encapsulation within the following macros, do not change
+-    ## the running order or otherwise move them around unless you know exactly
+-    ## what you are doing...
+-    lt_prog_compiler_wl_F77=
+-lt_prog_compiler_pic_F77=
+-lt_prog_compiler_static_F77=
+-
+-
+-  if test "$GCC" = yes; then
+-    lt_prog_compiler_wl_F77='-Wl,'
+-    lt_prog_compiler_static_F77='-static'
+-
+-    case $host_os in
+-      aix*)
+-      # All AIX code is PIC.
+-      if test "$host_cpu" = ia64; then
+-	# AIX 5 now supports IA64 processor
+-	lt_prog_compiler_static_F77='-Bstatic'
+-      fi
+-      ;;
+-
+-    amigaos*)
+-      case $host_cpu in
+-      powerpc)
+-            # see comment about AmigaOS4 .so support
+-            lt_prog_compiler_pic_F77='-fPIC'
+-        ;;
+-      m68k)
+-            # FIXME: we need at least 68020 code to build shared libraries, but
+-            # adding the `-m68020' flag to GCC prevents building anything better,
+-            # like `-m68040'.
+-            lt_prog_compiler_pic_F77='-m68020 -resident32 -malways-restore-a4'
+-        ;;
+-      esac
+-      ;;
+-
+-    beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
+-      # PIC is the default for these OSes.
+-      ;;
+-
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
+-      # This hack is so that the source file can tell whether it is being
+-      # built for inclusion in a dll (and should export symbols for example).
+-      # Although the cygwin gcc ignores -fPIC, still need this for old-style
+-      # (--disable-auto-import) libraries
+-      lt_prog_compiler_pic_F77='-DDLL_EXPORT'
+-      ;;
+-
+-    darwin* | rhapsody*)
+-      # PIC is the default on this platform
+-      # Common symbols not allowed in MH_DYLIB files
+-      lt_prog_compiler_pic_F77='-fno-common'
+-      ;;
+-
+-    haiku*)
+-      # PIC is the default for Haiku.
+-      # The "-static" flag exists, but is broken.
+-      lt_prog_compiler_static_F77=
+-      ;;
+-
+-    hpux*)
+-      # PIC is the default for 64-bit PA HP-UX, but not for 32-bit
+-      # PA HP-UX.  On IA64 HP-UX, PIC is the default but the pic flag
+-      # sets the default TLS model and affects inlining.
+-      case $host_cpu in
+-      hppa*64*)
+-	# +Z the default
+-	;;
+-      *)
+-	lt_prog_compiler_pic_F77='-fPIC'
+-	;;
+-      esac
+-      ;;
+-
+-    interix[3-9]*)
+-      # Interix 3.x gcc -fpic/-fPIC options generate broken code.
+-      # Instead, we relocate shared libraries at runtime.
+-      ;;
+-
+-    msdosdjgpp*)
+-      # Just because we use GCC doesn't mean we suddenly get shared libraries
+-      # on systems that don't support them.
+-      lt_prog_compiler_can_build_shared_F77=no
+-      enable_shared=no
+-      ;;
+-
+-    *nto* | *qnx*)
+-      # QNX uses GNU C++, but need to define -shared option too, otherwise
+-      # it will coredump.
+-      lt_prog_compiler_pic_F77='-fPIC -shared'
+-      ;;
+-
+-    sysv4*MP*)
+-      if test -d /usr/nec; then
+-	lt_prog_compiler_pic_F77=-Kconform_pic
+-      fi
+-      ;;
+-
+-    *)
+-      lt_prog_compiler_pic_F77='-fPIC'
+-      ;;
+-    esac
+-
+-    case $cc_basename in
+-    nvcc*) # Cuda Compiler Driver 2.2
+-      lt_prog_compiler_wl_F77='-Xlinker '
+-      lt_prog_compiler_pic_F77='-Xcompiler -fPIC'
+-      ;;
+-    esac
+-  else
+-    # PORTME Check for flag to pass linker flags through the system compiler.
+-    case $host_os in
+-    aix*)
+-      lt_prog_compiler_wl_F77='-Wl,'
+-      if test "$host_cpu" = ia64; then
+-	# AIX 5 now supports IA64 processor
+-	lt_prog_compiler_static_F77='-Bstatic'
+-      else
+-	lt_prog_compiler_static_F77='-bnso -bI:/lib/syscalls.exp'
+-      fi
+-      ;;
+-
+-    mingw* | cygwin* | pw32* | os2* | cegcc*)
+-      # This hack is so that the source file can tell whether it is being
+-      # built for inclusion in a dll (and should export symbols for example).
+-      lt_prog_compiler_pic_F77='-DDLL_EXPORT'
+-      ;;
+-
+-    hpux9* | hpux10* | hpux11*)
+-      lt_prog_compiler_wl_F77='-Wl,'
+-      # PIC is the default for IA64 HP-UX and 64-bit HP-UX, but
+-      # not for PA HP-UX.
+-      case $host_cpu in
+-      hppa*64*|ia64*)
+-	# +Z the default
+-	;;
+-      *)
+-	lt_prog_compiler_pic_F77='+Z'
+-	;;
+-      esac
+-      # Is there a better lt_prog_compiler_static that works with the bundled CC?
+-      lt_prog_compiler_static_F77='${wl}-a ${wl}archive'
+-      ;;
+-
+-    irix5* | irix6* | nonstopux*)
+-      lt_prog_compiler_wl_F77='-Wl,'
+-      # PIC (with -KPIC) is the default.
+-      lt_prog_compiler_static_F77='-non_shared'
+-      ;;
+-
+-    linux* | k*bsd*-gnu | kopensolaris*-gnu)
+-      case $cc_basename in
+-      # old Intel for x86_64 which still supported -KPIC.
+-      ecc*)
+-	lt_prog_compiler_wl_F77='-Wl,'
+-	lt_prog_compiler_pic_F77='-KPIC'
+-	lt_prog_compiler_static_F77='-static'
+-        ;;
+-      # icc used to be incompatible with GCC.
+-      # ICC 10 doesn't accept -KPIC any more.
+-      icc* | ifort*)
+-	lt_prog_compiler_wl_F77='-Wl,'
+-	lt_prog_compiler_pic_F77='-fPIC'
+-	lt_prog_compiler_static_F77='-static'
+-        ;;
+-      # Lahey Fortran 8.1.
+-      lf95*)
+-	lt_prog_compiler_wl_F77='-Wl,'
+-	lt_prog_compiler_pic_F77='--shared'
+-	lt_prog_compiler_static_F77='--static'
+-	;;
+-      nagfor*)
+-	# NAG Fortran compiler
+-	lt_prog_compiler_wl_F77='-Wl,-Wl,,'
+-	lt_prog_compiler_pic_F77='-PIC'
+-	lt_prog_compiler_static_F77='-Bstatic'
+-	;;
+-      pgcc* | pgf77* | pgf90* | pgf95* | pgfortran*)
+-        # Portland Group compilers (*not* the Pentium gcc compiler,
+-	# which looks to be a dead project)
+-	lt_prog_compiler_wl_F77='-Wl,'
+-	lt_prog_compiler_pic_F77='-fpic'
+-	lt_prog_compiler_static_F77='-Bstatic'
+-        ;;
+-      ccc*)
+-        lt_prog_compiler_wl_F77='-Wl,'
+-        # All Alpha code is PIC.
+-        lt_prog_compiler_static_F77='-non_shared'
+-        ;;
+-      xl* | bgxl* | bgf* | mpixl*)
+-	# IBM XL C 8.0/Fortran 10.1, 11.1 on PPC and BlueGene
+-	lt_prog_compiler_wl_F77='-Wl,'
+-	lt_prog_compiler_pic_F77='-qpic'
+-	lt_prog_compiler_static_F77='-qstaticlink'
+-	;;
+-      *)
+-	case `$CC -V 2>&1 | sed 5q` in
+-	*Sun\ F* | *Sun*Fortran*)
+-	  # Sun Fortran 8.3 passes all unrecognized flags to the linker
+-	  lt_prog_compiler_pic_F77='-KPIC'
+-	  lt_prog_compiler_static_F77='-Bstatic'
+-	  lt_prog_compiler_wl_F77=''
+-	  ;;
+-	*Sun\ C*)
+-	  # Sun C 5.9
+-	  lt_prog_compiler_pic_F77='-KPIC'
+-	  lt_prog_compiler_static_F77='-Bstatic'
+-	  lt_prog_compiler_wl_F77='-Wl,'
+-	  ;;
+-	esac
+-	;;
+-      esac
+-      ;;
+-
+-    newsos6)
+-      lt_prog_compiler_pic_F77='-KPIC'
+-      lt_prog_compiler_static_F77='-Bstatic'
+-      ;;
+-
+-    *nto* | *qnx*)
+-      # QNX uses GNU C++, but need to define -shared option too, otherwise
+-      # it will coredump.
+-      lt_prog_compiler_pic_F77='-fPIC -shared'
+-      ;;
+-
+-    osf3* | osf4* | osf5*)
+-      lt_prog_compiler_wl_F77='-Wl,'
+-      # All OSF/1 code is PIC.
+-      lt_prog_compiler_static_F77='-non_shared'
+-      ;;
+-
+-    rdos*)
+-      lt_prog_compiler_static_F77='-non_shared'
+-      ;;
+-
+-    solaris*)
+-      lt_prog_compiler_pic_F77='-KPIC'
+-      lt_prog_compiler_static_F77='-Bstatic'
+-      case $cc_basename in
+-      f77* | f90* | f95* | sunf77* | sunf90* | sunf95*)
+-	lt_prog_compiler_wl_F77='-Qoption ld ';;
+-      *)
+-	lt_prog_compiler_wl_F77='-Wl,';;
+-      esac
+-      ;;
+-
+-    sunos4*)
+-      lt_prog_compiler_wl_F77='-Qoption ld '
+-      lt_prog_compiler_pic_F77='-PIC'
+-      lt_prog_compiler_static_F77='-Bstatic'
+-      ;;
+-
+-    sysv4 | sysv4.2uw2* | sysv4.3*)
+-      lt_prog_compiler_wl_F77='-Wl,'
+-      lt_prog_compiler_pic_F77='-KPIC'
+-      lt_prog_compiler_static_F77='-Bstatic'
+-      ;;
+-
+-    sysv4*MP*)
+-      if test -d /usr/nec ;then
+-	lt_prog_compiler_pic_F77='-Kconform_pic'
+-	lt_prog_compiler_static_F77='-Bstatic'
+-      fi
+-      ;;
+-
+-    sysv5* | unixware* | sco3.2v5* | sco5v6* | OpenUNIX*)
+-      lt_prog_compiler_wl_F77='-Wl,'
+-      lt_prog_compiler_pic_F77='-KPIC'
+-      lt_prog_compiler_static_F77='-Bstatic'
+-      ;;
+-
+-    unicos*)
+-      lt_prog_compiler_wl_F77='-Wl,'
+-      lt_prog_compiler_can_build_shared_F77=no
+-      ;;
+-
+-    uts4*)
+-      lt_prog_compiler_pic_F77='-pic'
+-      lt_prog_compiler_static_F77='-Bstatic'
+-      ;;
+-
+-    *)
+-      lt_prog_compiler_can_build_shared_F77=no
+-      ;;
+-    esac
+-  fi
+-
+-case $host_os in
+-  # For platforms which do not support PIC, -DPIC is meaningless:
+-  *djgpp*)
+-    lt_prog_compiler_pic_F77=
+-    ;;
+-  *)
+-    lt_prog_compiler_pic_F77="$lt_prog_compiler_pic_F77"
+-    ;;
+-esac
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $compiler option to produce PIC" >&5
+-$as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+-if ${lt_cv_prog_compiler_pic_F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  lt_cv_prog_compiler_pic_F77=$lt_prog_compiler_pic_F77
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic_F77" >&5
+-$as_echo "$lt_cv_prog_compiler_pic_F77" >&6; }
+-lt_prog_compiler_pic_F77=$lt_cv_prog_compiler_pic_F77
+-
+-#
+-# Check to make sure the PIC flag actually works.
+-#
+-if test -n "$lt_prog_compiler_pic_F77"; then
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler PIC flag $lt_prog_compiler_pic_F77 works" >&5
+-$as_echo_n "checking if $compiler PIC flag $lt_prog_compiler_pic_F77 works... " >&6; }
+-if ${lt_cv_prog_compiler_pic_works_F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  lt_cv_prog_compiler_pic_works_F77=no
+-   ac_outfile=conftest.$ac_objext
+-   echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-   lt_compiler_flag="$lt_prog_compiler_pic_F77"
+-   # Insert the option either (1) after the last *FLAGS variable, or
+-   # (2) before a word containing "conftest.", or (3) at the end.
+-   # Note that $ac_compile itself does not contain backslashes and begins
+-   # with a dollar sign (not a hyphen), so the echo should work correctly.
+-   # The option is referenced via a variable to avoid confusing sed.
+-   lt_compile=`echo "$ac_compile" | $SED \
+-   -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
+-   -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
+-   -e 's:$: $lt_compiler_flag:'`
+-   (eval echo "\"\$as_me:$LINENO: $lt_compile\"" >&5)
+-   (eval "$lt_compile" 2>conftest.err)
+-   ac_status=$?
+-   cat conftest.err >&5
+-   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+-   if (exit $ac_status) && test -s "$ac_outfile"; then
+-     # The compiler can only warn and ignore the option if not recognized
+-     # So say no if there are warnings other than the usual output.
+-     $ECHO "$_lt_compiler_boilerplate" | $SED '/^$/d' >conftest.exp
+-     $SED '/^$/d; /^ *+/d' conftest.err >conftest.er2
+-     if test ! -s conftest.er2 || diff conftest.exp conftest.er2 >/dev/null; then
+-       lt_cv_prog_compiler_pic_works_F77=yes
+-     fi
+-   fi
+-   $RM conftest*
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic_works_F77" >&5
+-$as_echo "$lt_cv_prog_compiler_pic_works_F77" >&6; }
+-
+-if test x"$lt_cv_prog_compiler_pic_works_F77" = xyes; then
+-    case $lt_prog_compiler_pic_F77 in
+-     "" | " "*) ;;
+-     *) lt_prog_compiler_pic_F77=" $lt_prog_compiler_pic_F77" ;;
+-     esac
+-else
+-    lt_prog_compiler_pic_F77=
+-     lt_prog_compiler_can_build_shared_F77=no
+-fi
+-
+-fi
+-
+-
+-
+-
+-
+-#
+-# Check to make sure the static flag actually works.
+-#
+-wl=$lt_prog_compiler_wl_F77 eval lt_tmp_static_flag=\"$lt_prog_compiler_static_F77\"
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler static flag $lt_tmp_static_flag works" >&5
+-$as_echo_n "checking if $compiler static flag $lt_tmp_static_flag works... " >&6; }
+-if ${lt_cv_prog_compiler_static_works_F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  lt_cv_prog_compiler_static_works_F77=no
+-   save_LDFLAGS="$LDFLAGS"
+-   LDFLAGS="$LDFLAGS $lt_tmp_static_flag"
+-   echo "$lt_simple_link_test_code" > conftest.$ac_ext
+-   if (eval $ac_link 2>conftest.err) && test -s conftest$ac_exeext; then
+-     # The linker can only warn and ignore the option if not recognized
+-     # So say no if there are warnings
+-     if test -s conftest.err; then
+-       # Append any errors to the config.log.
+-       cat conftest.err 1>&5
+-       $ECHO "$_lt_linker_boilerplate" | $SED '/^$/d' > conftest.exp
+-       $SED '/^$/d; /^ *+/d' conftest.err >conftest.er2
+-       if diff conftest.exp conftest.er2 >/dev/null; then
+-         lt_cv_prog_compiler_static_works_F77=yes
+-       fi
+-     else
+-       lt_cv_prog_compiler_static_works_F77=yes
+-     fi
+-   fi
+-   $RM -r conftest*
+-   LDFLAGS="$save_LDFLAGS"
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_static_works_F77" >&5
+-$as_echo "$lt_cv_prog_compiler_static_works_F77" >&6; }
+-
+-if test x"$lt_cv_prog_compiler_static_works_F77" = xyes; then
+-    :
+-else
+-    lt_prog_compiler_static_F77=
+-fi
+-
+-
+-
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -c -o file.$ac_objext" >&5
+-$as_echo_n "checking if $compiler supports -c -o file.$ac_objext... " >&6; }
+-if ${lt_cv_prog_compiler_c_o_F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  lt_cv_prog_compiler_c_o_F77=no
+-   $RM -r conftest 2>/dev/null
+-   mkdir conftest
+-   cd conftest
+-   mkdir out
+-   echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-
+-   lt_compiler_flag="-o out/conftest2.$ac_objext"
+-   # Insert the option either (1) after the last *FLAGS variable, or
+-   # (2) before a word containing "conftest.", or (3) at the end.
+-   # Note that $ac_compile itself does not contain backslashes and begins
+-   # with a dollar sign (not a hyphen), so the echo should work correctly.
+-   lt_compile=`echo "$ac_compile" | $SED \
+-   -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
+-   -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
+-   -e 's:$: $lt_compiler_flag:'`
+-   (eval echo "\"\$as_me:$LINENO: $lt_compile\"" >&5)
+-   (eval "$lt_compile" 2>out/conftest.err)
+-   ac_status=$?
+-   cat out/conftest.err >&5
+-   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+-   if (exit $ac_status) && test -s out/conftest2.$ac_objext
+-   then
+-     # The compiler can only warn and ignore the option if not recognized
+-     # So say no if there are warnings
+-     $ECHO "$_lt_compiler_boilerplate" | $SED '/^$/d' > out/conftest.exp
+-     $SED '/^$/d; /^ *+/d' out/conftest.err >out/conftest.er2
+-     if test ! -s out/conftest.er2 || diff out/conftest.exp out/conftest.er2 >/dev/null; then
+-       lt_cv_prog_compiler_c_o_F77=yes
+-     fi
+-   fi
+-   chmod u+w . 2>&5
+-   $RM conftest*
+-   # SGI C++ compiler will create directory out/ii_files/ for
+-   # template instantiation
+-   test -d out/ii_files && $RM out/ii_files/* && rmdir out/ii_files
+-   $RM out/* && rmdir out
+-   cd ..
+-   $RM -r conftest
+-   $RM conftest*
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_c_o_F77" >&5
+-$as_echo "$lt_cv_prog_compiler_c_o_F77" >&6; }
+-
+-
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -c -o file.$ac_objext" >&5
+-$as_echo_n "checking if $compiler supports -c -o file.$ac_objext... " >&6; }
+-if ${lt_cv_prog_compiler_c_o_F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  lt_cv_prog_compiler_c_o_F77=no
+-   $RM -r conftest 2>/dev/null
+-   mkdir conftest
+-   cd conftest
+-   mkdir out
+-   echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-
+-   lt_compiler_flag="-o out/conftest2.$ac_objext"
+-   # Insert the option either (1) after the last *FLAGS variable, or
+-   # (2) before a word containing "conftest.", or (3) at the end.
+-   # Note that $ac_compile itself does not contain backslashes and begins
+-   # with a dollar sign (not a hyphen), so the echo should work correctly.
+-   lt_compile=`echo "$ac_compile" | $SED \
+-   -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
+-   -e 's: [^ ]*conftest\.: $lt_compiler_flag&:; t' \
+-   -e 's:$: $lt_compiler_flag:'`
+-   (eval echo "\"\$as_me:$LINENO: $lt_compile\"" >&5)
+-   (eval "$lt_compile" 2>out/conftest.err)
+-   ac_status=$?
+-   cat out/conftest.err >&5
+-   echo "$as_me:$LINENO: \$? = $ac_status" >&5
+-   if (exit $ac_status) && test -s out/conftest2.$ac_objext
+-   then
+-     # The compiler can only warn and ignore the option if not recognized
+-     # So say no if there are warnings
+-     $ECHO "$_lt_compiler_boilerplate" | $SED '/^$/d' > out/conftest.exp
+-     $SED '/^$/d; /^ *+/d' out/conftest.err >out/conftest.er2
+-     if test ! -s out/conftest.er2 || diff out/conftest.exp out/conftest.er2 >/dev/null; then
+-       lt_cv_prog_compiler_c_o_F77=yes
+-     fi
+-   fi
+-   chmod u+w . 2>&5
+-   $RM conftest*
+-   # SGI C++ compiler will create directory out/ii_files/ for
+-   # template instantiation
+-   test -d out/ii_files && $RM out/ii_files/* && rmdir out/ii_files
+-   $RM out/* && rmdir out
+-   cd ..
+-   $RM -r conftest
+-   $RM conftest*
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_c_o_F77" >&5
+-$as_echo "$lt_cv_prog_compiler_c_o_F77" >&6; }
+-
+-
+-
+-
+-hard_links="nottested"
+-if test "$lt_cv_prog_compiler_c_o_F77" = no && test "$need_locks" != no; then
+-  # do not overwrite the value of need_locks provided by the user
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can lock with hard links" >&5
+-$as_echo_n "checking if we can lock with hard links... " >&6; }
+-  hard_links=yes
+-  $RM conftest*
+-  ln conftest.a conftest.b 2>/dev/null && hard_links=no
+-  touch conftest.a
+-  ln conftest.a conftest.b 2>&5 || hard_links=no
+-  ln conftest.a conftest.b 2>/dev/null && hard_links=no
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $hard_links" >&5
+-$as_echo "$hard_links" >&6; }
+-  if test "$hard_links" = no; then
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe" >&5
+-$as_echo "$as_me: WARNING: \`$CC' does not support \`-c -o', so \`make -j' may be unsafe" >&2;}
+-    need_locks=warn
+-  fi
+-else
+-  need_locks=no
+-fi
+-
+-
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the $compiler linker ($LD) supports shared libraries" >&5
+-$as_echo_n "checking whether the $compiler linker ($LD) supports shared libraries... " >&6; }
+-
+-  runpath_var=
+-  allow_undefined_flag_F77=
+-  always_export_symbols_F77=no
+-  archive_cmds_F77=
+-  archive_expsym_cmds_F77=
+-  compiler_needs_object_F77=no
+-  enable_shared_with_static_runtimes_F77=no
+-  export_dynamic_flag_spec_F77=
+-  export_symbols_cmds_F77='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
+-  hardcode_automatic_F77=no
+-  hardcode_direct_F77=no
+-  hardcode_direct_absolute_F77=no
+-  hardcode_libdir_flag_spec_F77=
+-  hardcode_libdir_flag_spec_ld_F77=
+-  hardcode_libdir_separator_F77=
+-  hardcode_minus_L_F77=no
+-  hardcode_shlibpath_var_F77=unsupported
+-  inherit_rpath_F77=no
+-  link_all_deplibs_F77=unknown
+-  module_cmds_F77=
+-  module_expsym_cmds_F77=
+-  old_archive_from_new_cmds_F77=
+-  old_archive_from_expsyms_cmds_F77=
+-  thread_safe_flag_spec_F77=
+-  whole_archive_flag_spec_F77=
+-  # include_expsyms should be a list of space-separated symbols to be *always*
+-  # included in the symbol list
+-  include_expsyms_F77=
+-  # exclude_expsyms can be an extended regexp of symbols to exclude
+-  # it will be wrapped by ` (' and `)$', so one must not match beginning or
+-  # end of line.  Example: `a|bc|.*d.*' will exclude the symbols `a' and `bc',
+-  # as well as any symbol that contains `d'.
+-  exclude_expsyms_F77='_GLOBAL_OFFSET_TABLE_|_GLOBAL__F[ID]_.*'
+-  # Although _GLOBAL_OFFSET_TABLE_ is a valid symbol C name, most a.out
+-  # platforms (ab)use it in PIC code, but their linkers get confused if
+-  # the symbol is explicitly referenced.  Since portable code cannot
+-  # rely on this symbol name, it's probably fine to never include it in
+-  # preloaded symbol tables.
+-  # Exclude shared library initialization/finalization symbols.
+-  extract_expsyms_cmds=
+-
+-  case $host_os in
+-  cygwin* | mingw* | pw32* | cegcc*)
+-    # FIXME: the MSVC++ port hasn't been tested in a loooong time
+-    # When not using gcc, we currently assume that we are using
+-    # Microsoft Visual C++.
+-    if test "$GCC" != yes; then
+-      with_gnu_ld=no
+-    fi
+-    ;;
+-  interix*)
+-    # we just hope/assume this is gcc and not c89 (= MSVC++)
+-    with_gnu_ld=yes
+-    ;;
+-  openbsd*)
+-    with_gnu_ld=no
+-    ;;
+-  esac
+-
+-  ld_shlibs_F77=yes
+-
+-  # On some targets, GNU ld is compatible enough with the native linker
+-  # that we're better off using the native interface for both.
+-  lt_use_gnu_ld_interface=no
+-  if test "$with_gnu_ld" = yes; then
+-    case $host_os in
+-      aix*)
+-	# The AIX port of GNU ld has always aspired to compatibility
+-	# with the native linker.  However, as the warning in the GNU ld
+-	# block says, versions before 2.19.5* couldn't really create working
+-	# shared libraries, regardless of the interface used.
+-	case `$LD -v 2>&1` in
+-	  *\ \(GNU\ Binutils\)\ 2.19.5*) ;;
+-	  *\ \(GNU\ Binutils\)\ 2.[2-9]*) ;;
+-	  *\ \(GNU\ Binutils\)\ [3-9]*) ;;
+-	  *)
+-	    lt_use_gnu_ld_interface=yes
+-	    ;;
+-	esac
+-	;;
+-      *)
+-	lt_use_gnu_ld_interface=yes
+-	;;
+-    esac
+-  fi
+-
+-  if test "$lt_use_gnu_ld_interface" = yes; then
+-    # If archive_cmds runs LD, not CC, wlarc should be empty
+-    wlarc='${wl}'
+-
+-    # Set some defaults for GNU ld with shared library support. These
+-    # are reset later if shared libraries are not supported. Putting them
+-    # here allows them to be overridden if necessary.
+-    runpath_var=LD_RUN_PATH
+-    hardcode_libdir_flag_spec_F77='${wl}-rpath ${wl}$libdir'
+-    export_dynamic_flag_spec_F77='${wl}--export-dynamic'
+-    # ancient GNU ld didn't support --whole-archive et. al.
+-    if $LD --help 2>&1 | $GREP 'no-whole-archive' > /dev/null; then
+-      whole_archive_flag_spec_F77="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
+-    else
+-      whole_archive_flag_spec_F77=
+-    fi
+-    supports_anon_versioning=no
+-    case `$LD -v 2>&1` in
+-      *GNU\ gold*) supports_anon_versioning=yes ;;
+-      *\ [01].* | *\ 2.[0-9].* | *\ 2.10.*) ;; # catch versions < 2.11
+-      *\ 2.11.93.0.2\ *) supports_anon_versioning=yes ;; # RH7.3 ...
+-      *\ 2.11.92.0.12\ *) supports_anon_versioning=yes ;; # Mandrake 8.2 ...
+-      *\ 2.11.*) ;; # other 2.11 versions
+-      *) supports_anon_versioning=yes ;;
+-    esac
+-
+-    # See if GNU ld supports shared libraries.
+-    case $host_os in
+-    aix[3-9]*)
+-      # On AIX/PPC, the GNU linker is very broken
+-      if test "$host_cpu" != ia64; then
+-	ld_shlibs_F77=no
+-	cat <<_LT_EOF 1>&2
+-
+-*** Warning: the GNU linker, at least up to release 2.19, is reported
+-*** to be unable to reliably create shared libraries on AIX.
+-*** Therefore, libtool is disabling shared libraries support.  If you
+-*** really care for shared libraries, you may want to install binutils
+-*** 2.20 or above, or modify your PATH so that a non-GNU linker is found.
+-*** You will then need to restart the configuration process.
+-
+-_LT_EOF
+-      fi
+-      ;;
+-
+-    amigaos*)
+-      case $host_cpu in
+-      powerpc)
+-            # see comment about AmigaOS4 .so support
+-            archive_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-            archive_expsym_cmds_F77=''
+-        ;;
+-      m68k)
+-            archive_cmds_F77='$RM $output_objdir/a2ixlibrary.data~$ECHO "#define NAME $libname" > $output_objdir/a2ixlibrary.data~$ECHO "#define LIBRARY_ID 1" >> $output_objdir/a2ixlibrary.data~$ECHO "#define VERSION $major" >> $output_objdir/a2ixlibrary.data~$ECHO "#define REVISION $revision" >> $output_objdir/a2ixlibrary.data~$AR $AR_FLAGS $lib $libobjs~$RANLIB $lib~(cd $output_objdir && a2ixlibrary -32)'
+-            hardcode_libdir_flag_spec_F77='-L$libdir'
+-            hardcode_minus_L_F77=yes
+-        ;;
+-      esac
+-      ;;
+-
+-    beos*)
+-      if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	allow_undefined_flag_F77=unsupported
+-	# Joseph Beckenbach <jrb3@best.com> says some releases of gcc
+-	# support --undefined.  This deserves some investigation.  FIXME
+-	archive_cmds_F77='$CC -nostart $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-      else
+-	ld_shlibs_F77=no
+-      fi
+-      ;;
+-
+-    cygwin* | mingw* | pw32* | cegcc*)
+-      # _LT_TAGVAR(hardcode_libdir_flag_spec, F77) is actually meaningless,
+-      # as there is no search path for DLLs.
+-      hardcode_libdir_flag_spec_F77='-L$libdir'
+-      export_dynamic_flag_spec_F77='${wl}--export-all-symbols'
+-      allow_undefined_flag_F77=unsupported
+-      always_export_symbols_F77=no
+-      enable_shared_with_static_runtimes_F77=yes
+-      export_symbols_cmds_F77='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[BCDGRS][ ]/s/.*[ ]\([^ ]*\)/\1 DATA/;s/^.*[ ]__nm__\([^ ]*\)[ ][^ ]*/\1 DATA/;/^I[ ]/d;/^[AITW][ ]/s/.* //'\'' | sort | uniq > $export_symbols'
+-      exclude_expsyms_F77='[_]+GLOBAL_OFFSET_TABLE_|[_]+GLOBAL__[FID]_.*|[_]+head_[A-Za-z0-9_]+_dll|[A-Za-z0-9_]+_dll_iname'
+-
+-      if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
+-        archive_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+-	# If the export-symbols file already is a .def file (1st line
+-	# is EXPORTS), use it as is; otherwise, prepend...
+-	archive_expsym_cmds_F77='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	  cp $export_symbols $output_objdir/$soname.def;
+-	else
+-	  echo EXPORTS > $output_objdir/$soname.def;
+-	  cat $export_symbols >> $output_objdir/$soname.def;
+-	fi~
+-	$CC -shared $output_objdir/$soname.def $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
+-      else
+-	ld_shlibs_F77=no
+-      fi
+-      ;;
+-
+-    haiku*)
+-      archive_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-      link_all_deplibs_F77=yes
+-      ;;
+-
+-    interix[3-9]*)
+-      hardcode_direct_F77=no
+-      hardcode_shlibpath_var_F77=no
+-      hardcode_libdir_flag_spec_F77='${wl}-rpath,$libdir'
+-      export_dynamic_flag_spec_F77='${wl}-E'
+-      # Hack: On Interix 3.x, we cannot compile PIC because of a broken gcc.
+-      # Instead, shared libraries are loaded at an image base (0x10000000 by
+-      # default) and relocated if they conflict, which is a slow very memory
+-      # consuming and fragmenting process.  To avoid this, we pick a random,
+-      # 256 KiB-aligned image base between 0x50000000 and 0x6FFC0000 at link
+-      # time.  Moving up from 0x10000000 also allows more sbrk(2) space.
+-      archive_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+-      archive_expsym_cmds_F77='sed "s,^,_," $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--retain-symbols-file,$output_objdir/$soname.expsym ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
+-      ;;
+-
+-    gnu* | linux* | tpf* | k*bsd*-gnu | kopensolaris*-gnu)
+-      tmp_diet=no
+-      if test "$host_os" = linux-dietlibc; then
+-	case $cc_basename in
+-	  diet\ *) tmp_diet=yes;;	# linux-dietlibc with static linking (!diet-dyn)
+-	esac
+-      fi
+-      if $LD --help 2>&1 | $EGREP ': supported targets:.* elf' > /dev/null \
+-	 && test "$tmp_diet" = no
+-      then
+-	tmp_addflag=' $pic_flag'
+-	tmp_sharedflag='-shared'
+-	case $cc_basename,$host_cpu in
+-        pgcc*)				# Portland Group C compiler
+-	  whole_archive_flag_spec_F77='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
+-	  tmp_addflag=' $pic_flag'
+-	  ;;
+-	pgf77* | pgf90* | pgf95* | pgfortran*)
+-					# Portland Group f77 and f90 compilers
+-	  whole_archive_flag_spec_F77='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
+-	  tmp_addflag=' $pic_flag -Mnomain' ;;
+-	ecc*,ia64* | icc*,ia64*)	# Intel C compiler on ia64
+-	  tmp_addflag=' -i_dynamic' ;;
+-	efc*,ia64* | ifort*,ia64*)	# Intel Fortran compiler on ia64
+-	  tmp_addflag=' -i_dynamic -nofor_main' ;;
+-	ifc* | ifort*)			# Intel Fortran compiler
+-	  tmp_addflag=' -nofor_main' ;;
+-	lf95*)				# Lahey Fortran 8.1
+-	  whole_archive_flag_spec_F77=
+-	  tmp_sharedflag='--shared' ;;
+-	xl[cC]* | bgxl[cC]* | mpixl[cC]*) # IBM XL C 8.0 on PPC (deal with xlf below)
+-	  tmp_sharedflag='-qmkshrobj'
+-	  tmp_addflag= ;;
+-	nvcc*)	# Cuda Compiler Driver 2.2
+-	  whole_archive_flag_spec_F77='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
+-	  compiler_needs_object_F77=yes
+-	  ;;
+-	esac
+-	case `$CC -V 2>&1 | sed 5q` in
+-	*Sun\ C*)			# Sun C 5.9
+-	  whole_archive_flag_spec_F77='${wl}--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
+-	  compiler_needs_object_F77=yes
+-	  tmp_sharedflag='-G' ;;
+-	*Sun\ F*)			# Sun Fortran 8.3
+-	  tmp_sharedflag='-G' ;;
+-	esac
+-	archive_cmds_F77='$CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-
+-        if test "x$supports_anon_versioning" = xyes; then
+-          archive_expsym_cmds_F77='echo "{ global:" > $output_objdir/$libname.ver~
+-	    cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-	    echo "local: *; };" >> $output_objdir/$libname.ver~
+-	    $CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-version-script ${wl}$output_objdir/$libname.ver -o $lib'
+-        fi
+-
+-	case $cc_basename in
+-	xlf* | bgf* | bgxlf* | mpixlf*)
+-	  # IBM XL Fortran 10.1 on PPC cannot create shared libs itself
+-	  whole_archive_flag_spec_F77='--whole-archive$convenience --no-whole-archive'
+-	  hardcode_libdir_flag_spec_F77=
+-	  hardcode_libdir_flag_spec_ld_F77='-rpath $libdir'
+-	  archive_cmds_F77='$LD -shared $libobjs $deplibs $linker_flags -soname $soname -o $lib'
+-	  if test "x$supports_anon_versioning" = xyes; then
+-	    archive_expsym_cmds_F77='echo "{ global:" > $output_objdir/$libname.ver~
+-	      cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
+-	      echo "local: *; };" >> $output_objdir/$libname.ver~
+-	      $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
+-	  fi
+-	  ;;
+-	esac
+-      else
+-        ld_shlibs_F77=no
+-      fi
+-      ;;
+-
+-    netbsd*)
+-      if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+-	archive_cmds_F77='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
+-	wlarc=
+-      else
+-	archive_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	archive_expsym_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
+-      fi
+-      ;;
+-
+-    solaris*)
+-      if $LD -v 2>&1 | $GREP 'BFD 2\.8' > /dev/null; then
+-	ld_shlibs_F77=no
+-	cat <<_LT_EOF 1>&2
+-
+-*** Warning: The releases 2.8.* of the GNU linker cannot reliably
+-*** create shared libraries on Solaris systems.  Therefore, libtool
+-*** is disabling shared libraries support.  We urge you to upgrade GNU
+-*** binutils to release 2.9.1 or newer.  Another option is to modify
+-*** your PATH or compiler configuration so that the native linker is
+-*** used, and then restart.
+-
+-_LT_EOF
+-      elif $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	archive_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	archive_expsym_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
+-      else
+-	ld_shlibs_F77=no
+-      fi
+-      ;;
+-
+-    sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX*)
+-      case `$LD -v 2>&1` in
+-        *\ [01].* | *\ 2.[0-9].* | *\ 2.1[0-5].*)
+-	ld_shlibs_F77=no
+-	cat <<_LT_EOF 1>&2
+-
+-*** Warning: Releases of the GNU linker prior to 2.16.91.0.3 can not
+-*** reliably create shared libraries on SCO systems.  Therefore, libtool
+-*** is disabling shared libraries support.  We urge you to upgrade GNU
+-*** binutils to release 2.16.91.0.3 or newer.  Another option is to modify
+-*** your PATH or compiler configuration so that the native linker is
+-*** used, and then restart.
+-
+-_LT_EOF
+-	;;
+-	*)
+-	  # For security reasons, it is highly recommended that you always
+-	  # use absolute paths for naming shared libraries, and exclude the
+-	  # DT_RUNPATH tag from executables and libraries.  But doing so
+-	  # requires that you compile everything twice, which is a pain.
+-	  if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	    hardcode_libdir_flag_spec_F77='${wl}-rpath ${wl}$libdir'
+-	    archive_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	    archive_expsym_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
+-	  else
+-	    ld_shlibs_F77=no
+-	  fi
+-	;;
+-      esac
+-      ;;
+-
+-    sunos4*)
+-      archive_cmds_F77='$LD -assert pure-text -Bshareable -o $lib $libobjs $deplibs $linker_flags'
+-      wlarc=
+-      hardcode_direct_F77=yes
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    *)
+-      if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
+-	archive_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-	archive_expsym_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
+-      else
+-	ld_shlibs_F77=no
+-      fi
+-      ;;
+-    esac
+-
+-    if test "$ld_shlibs_F77" = no; then
+-      runpath_var=
+-      hardcode_libdir_flag_spec_F77=
+-      export_dynamic_flag_spec_F77=
+-      whole_archive_flag_spec_F77=
+-    fi
+-  else
+-    # PORTME fill in a description of your system's linker (not GNU ld)
+-    case $host_os in
+-    aix3*)
+-      allow_undefined_flag_F77=unsupported
+-      always_export_symbols_F77=yes
+-      archive_expsym_cmds_F77='$LD -o $output_objdir/$soname $libobjs $deplibs $linker_flags -bE:$export_symbols -T512 -H512 -bM:SRE~$AR $AR_FLAGS $lib $output_objdir/$soname'
+-      # Note: this linker hardcodes the directories in LIBPATH if there
+-      # are no directories specified by -L.
+-      hardcode_minus_L_F77=yes
+-      if test "$GCC" = yes && test -z "$lt_prog_compiler_static"; then
+-	# Neither direct hardcoding nor static linking is supported with a
+-	# broken collect2.
+-	hardcode_direct_F77=unsupported
+-      fi
+-      ;;
+-
+-    aix[4-9]*)
+-      if test "$host_cpu" = ia64; then
+-	# On IA64, the linker does run time linking by default, so we don't
+-	# have to do anything special.
+-	aix_use_runtimelinking=no
+-	exp_sym_flag='-Bexport'
+-	no_entry_flag=""
+-      else
+-	# If we're using GNU nm, then we don't want the "-C" option.
+-	# -C means demangle to AIX nm, but means don't demangle with GNU nm
+-	# Also, AIX nm treats weak defined symbols like other global
+-	# defined symbols, whereas GNU nm marks them as "W".
+-	if $NM -V 2>&1 | $GREP 'GNU' > /dev/null; then
+-	  export_symbols_cmds_F77='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && (substr(\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
+-	else
+-	  export_symbols_cmds_F77='$NM -BCpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B")) && (substr(\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
+-	fi
+-	aix_use_runtimelinking=no
+-
+-	# Test if we are trying to use run time linking or normal
+-	# AIX style linking. If -brtl is somewhere in LDFLAGS, we
+-	# need to do runtime linking.
+-	case $host_os in aix4.[23]|aix4.[23].*|aix[5-9]*)
+-	  for ld_flag in $LDFLAGS; do
+-	  if (test $ld_flag = "-brtl" || test $ld_flag = "-Wl,-brtl"); then
+-	    aix_use_runtimelinking=yes
+-	    break
+-	  fi
+-	  done
+-	  ;;
+-	esac
+-
+-	exp_sym_flag='-bexport'
+-	no_entry_flag='-bnoentry'
+-      fi
+-
+-      # When large executables or shared objects are built, AIX ld can
+-      # have problems creating the table of contents.  If linking a library
+-      # or program results in "error TOC overflow" add -mminimal-toc to
+-      # CXXFLAGS/CFLAGS for g++/gcc.  In the cases where that is not
+-      # enough to fix the problem, add -Wl,-bbigtoc to LDFLAGS.
+-
+-      archive_cmds_F77=''
+-      hardcode_direct_F77=yes
+-      hardcode_direct_absolute_F77=yes
+-      hardcode_libdir_separator_F77=':'
+-      link_all_deplibs_F77=yes
+-      file_list_spec_F77='${wl}-f,'
+-
+-      if test "$GCC" = yes; then
+-	case $host_os in aix4.[012]|aix4.[012].*)
+-	# We only want to do this on AIX 4.2 and lower, the check
+-	# below for broken collect2 doesn't work under 4.3+
+-	  collect2name=`${CC} -print-prog-name=collect2`
+-	  if test -f "$collect2name" &&
+-	   strings "$collect2name" | $GREP resolve_lib_name >/dev/null
+-	  then
+-	  # We have reworked collect2
+-	  :
+-	  else
+-	  # We have old collect2
+-	  hardcode_direct_F77=unsupported
+-	  # It fails to find uninstalled libraries when the uninstalled
+-	  # path is not listed in the libpath.  Setting hardcode_minus_L
+-	  # to unsupported forces relinking
+-	  hardcode_minus_L_F77=yes
+-	  hardcode_libdir_flag_spec_F77='-L$libdir'
+-	  hardcode_libdir_separator_F77=
+-	  fi
+-	  ;;
+-	esac
+-	shared_flag='-shared'
+-	if test "$aix_use_runtimelinking" = yes; then
+-	  shared_flag="$shared_flag "'${wl}-G'
+-	fi
+-      else
+-	# not using gcc
+-	if test "$host_cpu" = ia64; then
+-	# VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
+-	# chokes on -Wl,-G. The following line is correct:
+-	  shared_flag='-G'
+-	else
+-	  if test "$aix_use_runtimelinking" = yes; then
+-	    shared_flag='${wl}-G'
+-	  else
+-	    shared_flag='${wl}-bM:SRE'
+-	  fi
+-	fi
+-      fi
+-
+-      export_dynamic_flag_spec_F77='${wl}-bexpall'
+-      # It seems that -bexpall does not export symbols beginning with
+-      # underscore (_), so it is better to generate a list of symbols to export.
+-      always_export_symbols_F77=yes
+-      if test "$aix_use_runtimelinking" = yes; then
+-	# Warning - without using the other runtime loading flags (-brtl),
+-	# -berok will link without error, but may produce a broken library.
+-	allow_undefined_flag_F77='-berok'
+-        # Determine the default libpath from the value encoded in an
+-        # empty executable.
+-        if test "${lt_cv_aix_libpath+set}" = set; then
+-  aix_libpath=$lt_cv_aix_libpath
+-else
+-  if ${lt_cv_aix_libpath__F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat > conftest.$ac_ext <<_ACEOF
+-      program main
+-
+-      end
+-_ACEOF
+-if ac_fn_f77_try_link "$LINENO"; then :
+-
+-  lt_aix_libpath_sed='
+-      /Import File Strings/,/^$/ {
+-	  /^0/ {
+-	      s/^0  *\([^ ]*\) *$/\1/
+-	      p
+-	  }
+-      }'
+-  lt_cv_aix_libpath__F77=`dump -H conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
+-  # Check for a 64-bit object if we didn't find anything.
+-  if test -z "$lt_cv_aix_libpath__F77"; then
+-    lt_cv_aix_libpath__F77=`dump -HX64 conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
+-  fi
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-  if test -z "$lt_cv_aix_libpath__F77"; then
+-    lt_cv_aix_libpath__F77="/usr/lib:/lib"
+-  fi
+-
+-fi
+-
+-  aix_libpath=$lt_cv_aix_libpath__F77
+-fi
+-
+-        hardcode_libdir_flag_spec_F77='${wl}-blibpath:$libdir:'"$aix_libpath"
+-        archive_expsym_cmds_F77='$CC -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags `if test "x${allow_undefined_flag}" != "x"; then func_echo_all "${wl}${allow_undefined_flag}"; else :; fi` '"\${wl}$exp_sym_flag:\$export_symbols $shared_flag"
+-      else
+-	if test "$host_cpu" = ia64; then
+-	  hardcode_libdir_flag_spec_F77='${wl}-R $libdir:/usr/lib:/lib'
+-	  allow_undefined_flag_F77="-z nodefs"
+-	  archive_expsym_cmds_F77="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags ${wl}${allow_undefined_flag} '"\${wl}$exp_sym_flag:\$export_symbols"
+-	else
+-	 # Determine the default libpath from the value encoded in an
+-	 # empty executable.
+-	 if test "${lt_cv_aix_libpath+set}" = set; then
+-  aix_libpath=$lt_cv_aix_libpath
+-else
+-  if ${lt_cv_aix_libpath__F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  cat > conftest.$ac_ext <<_ACEOF
+-      program main
+-
+-      end
+-_ACEOF
+-if ac_fn_f77_try_link "$LINENO"; then :
+-
+-  lt_aix_libpath_sed='
+-      /Import File Strings/,/^$/ {
+-	  /^0/ {
+-	      s/^0  *\([^ ]*\) *$/\1/
+-	      p
+-	  }
+-      }'
+-  lt_cv_aix_libpath__F77=`dump -H conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
+-  # Check for a 64-bit object if we didn't find anything.
+-  if test -z "$lt_cv_aix_libpath__F77"; then
+-    lt_cv_aix_libpath__F77=`dump -HX64 conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
+-  fi
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-  if test -z "$lt_cv_aix_libpath__F77"; then
+-    lt_cv_aix_libpath__F77="/usr/lib:/lib"
+-  fi
+-
+-fi
+-
+-  aix_libpath=$lt_cv_aix_libpath__F77
+-fi
+-
+-	 hardcode_libdir_flag_spec_F77='${wl}-blibpath:$libdir:'"$aix_libpath"
+-	  # Warning - without using the other run time loading flags,
+-	  # -berok will link without error, but may produce a broken library.
+-	  no_undefined_flag_F77=' ${wl}-bernotok'
+-	  allow_undefined_flag_F77=' ${wl}-berok'
+-	  if test "$with_gnu_ld" = yes; then
+-	    # We only use this code for GNU lds that support --whole-archive.
+-	    whole_archive_flag_spec_F77='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
+-	  else
+-	    # Exported symbols can be pulled into shared objects from archives
+-	    whole_archive_flag_spec_F77='$convenience'
+-	  fi
+-	  archive_cmds_need_lc_F77=yes
+-	  # This is similar to how AIX traditionally builds its shared libraries.
+-	  archive_expsym_cmds_F77="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs ${wl}-bnoentry $compiler_flags ${wl}-bE:$export_symbols${allow_undefined_flag}~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$soname'
+-	fi
+-      fi
+-      ;;
+-
+-    amigaos*)
+-      case $host_cpu in
+-      powerpc)
+-            # see comment about AmigaOS4 .so support
+-            archive_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
+-            archive_expsym_cmds_F77=''
+-        ;;
+-      m68k)
+-            archive_cmds_F77='$RM $output_objdir/a2ixlibrary.data~$ECHO "#define NAME $libname" > $output_objdir/a2ixlibrary.data~$ECHO "#define LIBRARY_ID 1" >> $output_objdir/a2ixlibrary.data~$ECHO "#define VERSION $major" >> $output_objdir/a2ixlibrary.data~$ECHO "#define REVISION $revision" >> $output_objdir/a2ixlibrary.data~$AR $AR_FLAGS $lib $libobjs~$RANLIB $lib~(cd $output_objdir && a2ixlibrary -32)'
+-            hardcode_libdir_flag_spec_F77='-L$libdir'
+-            hardcode_minus_L_F77=yes
+-        ;;
+-      esac
+-      ;;
+-
+-    bsdi[45]*)
+-      export_dynamic_flag_spec_F77=-rdynamic
+-      ;;
+-
+-    cygwin* | mingw* | pw32* | cegcc*)
+-      # When not using gcc, we currently assume that we are using
+-      # Microsoft Visual C++.
+-      # hardcode_libdir_flag_spec is actually meaningless, as there is
+-      # no search path for DLLs.
+-      case $cc_basename in
+-      cl*)
+-	# Native MSVC
+-	hardcode_libdir_flag_spec_F77=' '
+-	allow_undefined_flag_F77=unsupported
+-	always_export_symbols_F77=yes
+-	file_list_spec_F77='@'
+-	# Tell ltmain to make .lib files, not .a files.
+-	libext=lib
+-	# Tell ltmain to make .dll files, not .so files.
+-	shrext_cmds=".dll"
+-	# FIXME: Setting linknames here is a bad hack.
+-	archive_cmds_F77='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-dll~linknames='
+-	archive_expsym_cmds_F77='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
+-	    sed -n -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' -e '1\\\!p' < $export_symbols > $output_objdir/$soname.exp;
+-	  else
+-	    sed -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' < $export_symbols > $output_objdir/$soname.exp;
+-	  fi~
+-	  $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
+-	  linknames='
+-	# The linker will not automatically build a static lib if we build a DLL.
+-	# _LT_TAGVAR(old_archive_from_new_cmds, F77)='true'
+-	enable_shared_with_static_runtimes_F77=yes
+-	export_symbols_cmds_F77='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[BCDGRS][ ]/s/.*[ ]\([^ ]*\)/\1,DATA/'\'' | $SED -e '\''/^[AITW][ ]/s/.*[ ]//'\'' | sort | uniq > $export_symbols'
+-	# Don't use ranlib
+-	old_postinstall_cmds_F77='chmod 644 $oldlib'
+-	postlink_cmds_F77='lt_outputfile="@OUTPUT@"~
+-	  lt_tool_outputfile="@TOOL_OUTPUT@"~
+-	  case $lt_outputfile in
+-	    *.exe|*.EXE) ;;
+-	    *)
+-	      lt_outputfile="$lt_outputfile.exe"
+-	      lt_tool_outputfile="$lt_tool_outputfile.exe"
+-	      ;;
+-	  esac~
+-	  if test "$MANIFEST_TOOL" != ":" && test -f "$lt_outputfile.manifest"; then
+-	    $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
+-	    $RM "$lt_outputfile.manifest";
+-	  fi'
+-	;;
+-      *)
+-	# Assume MSVC wrapper
+-	hardcode_libdir_flag_spec_F77=' '
+-	allow_undefined_flag_F77=unsupported
+-	# Tell ltmain to make .lib files, not .a files.
+-	libext=lib
+-	# Tell ltmain to make .dll files, not .so files.
+-	shrext_cmds=".dll"
+-	# FIXME: Setting linknames here is a bad hack.
+-	archive_cmds_F77='$CC -o $lib $libobjs $compiler_flags `func_echo_all "$deplibs" | $SED '\''s/ -lc$//'\''` -link -dll~linknames='
+-	# The linker will automatically build a .lib file if we build a DLL.
+-	old_archive_from_new_cmds_F77='true'
+-	# FIXME: Should let the user specify the lib program.
+-	old_archive_cmds_F77='lib -OUT:$oldlib$oldobjs$old_deplibs'
+-	enable_shared_with_static_runtimes_F77=yes
+-	;;
+-      esac
+-      ;;
+-
+-    darwin* | rhapsody*)
+-
+-
+-  archive_cmds_need_lc_F77=no
+-  hardcode_direct_F77=no
+-  hardcode_automatic_F77=yes
+-  hardcode_shlibpath_var_F77=unsupported
+-  if test "$lt_cv_ld_force_load" = "yes"; then
+-    whole_archive_flag_spec_F77='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience ${wl}-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
+-  else
+-    whole_archive_flag_spec_F77=''
+-  fi
+-  link_all_deplibs_F77=yes
+-  allow_undefined_flag_F77="$_lt_dar_allow_undefined"
+-  case $cc_basename in
+-     ifort*) _lt_dar_can_shared=yes ;;
+-     *) _lt_dar_can_shared=$GCC ;;
+-  esac
+-  if test "$_lt_dar_can_shared" = "yes"; then
+-    output_verbose_link_cmd=func_echo_all
+-    archive_cmds_F77="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod${_lt_dsymutil}"
+-    module_cmds_F77="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dsymutil}"
+-    archive_expsym_cmds_F77="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring ${_lt_dar_single_mod}${_lt_dar_export_syms}${_lt_dsymutil}"
+-    module_expsym_cmds_F77="sed -e 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dar_export_syms}${_lt_dsymutil}"
+-
+-  else
+-  ld_shlibs_F77=no
+-  fi
+-
+-      ;;
+-
+-    dgux*)
+-      archive_cmds_F77='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-      hardcode_libdir_flag_spec_F77='-L$libdir'
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    freebsd1*)
+-      ld_shlibs_F77=no
+-      ;;
+-
+-    # FreeBSD 2.2.[012] allows us to include c++rt0.o to get C++ constructor
+-    # support.  Future versions do this automatically, but an explicit c++rt0.o
+-    # does not break anything, and helps significantly (at the cost of a little
+-    # extra space).
+-    freebsd2.2*)
+-      archive_cmds_F77='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags /usr/lib/c++rt0.o'
+-      hardcode_libdir_flag_spec_F77='-R$libdir'
+-      hardcode_direct_F77=yes
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    # Unfortunately, older versions of FreeBSD 2 do not have this feature.
+-    freebsd2*)
+-      archive_cmds_F77='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'
+-      hardcode_direct_F77=yes
+-      hardcode_minus_L_F77=yes
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    # FreeBSD 3 and greater uses gcc -shared to do shared libraries.
+-    freebsd* | dragonfly*)
+-      archive_cmds_F77='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
+-      hardcode_libdir_flag_spec_F77='-R$libdir'
+-      hardcode_direct_F77=yes
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    hpux9*)
+-      if test "$GCC" = yes; then
+-	archive_cmds_F77='$RM $output_objdir/$soname~$CC -shared $pic_flag ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $libobjs $deplibs $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
+-      else
+-	archive_cmds_F77='$RM $output_objdir/$soname~$LD -b +b $install_libdir -o $output_objdir/$soname $libobjs $deplibs $linker_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
+-      fi
+-      hardcode_libdir_flag_spec_F77='${wl}+b ${wl}$libdir'
+-      hardcode_libdir_separator_F77=:
+-      hardcode_direct_F77=yes
+-
+-      # hardcode_minus_L: Not really in the search PATH,
+-      # but as the default location of the library.
+-      hardcode_minus_L_F77=yes
+-      export_dynamic_flag_spec_F77='${wl}-E'
+-      ;;
+-
+-    hpux10*)
+-      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
+-	archive_cmds_F77='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+-      else
+-	archive_cmds_F77='$LD -b +h $soname +b $install_libdir -o $lib $libobjs $deplibs $linker_flags'
+-      fi
+-      if test "$with_gnu_ld" = no; then
+-	hardcode_libdir_flag_spec_F77='${wl}+b ${wl}$libdir'
+-	hardcode_libdir_flag_spec_ld_F77='+b $libdir'
+-	hardcode_libdir_separator_F77=:
+-	hardcode_direct_F77=yes
+-	hardcode_direct_absolute_F77=yes
+-	export_dynamic_flag_spec_F77='${wl}-E'
+-	# hardcode_minus_L: Not really in the search PATH,
+-	# but as the default location of the library.
+-	hardcode_minus_L_F77=yes
+-      fi
+-      ;;
+-
+-    hpux11*)
+-      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
+-	case $host_cpu in
+-	hppa*64*)
+-	  archive_cmds_F77='$CC -shared ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	  ;;
+-	ia64*)
+-	  archive_cmds_F77='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
+-	  ;;
+-	*)
+-	  archive_cmds_F77='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+-	  ;;
+-	esac
+-      else
+-	case $host_cpu in
+-	hppa*64*)
+-	  archive_cmds_F77='$CC -b ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	  ;;
+-	ia64*)
+-	  archive_cmds_F77='$CC -b ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
+-	  ;;
+-	*)
+-	archive_cmds_F77='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
+-	  ;;
+-	esac
+-      fi
+-      if test "$with_gnu_ld" = no; then
+-	hardcode_libdir_flag_spec_F77='${wl}+b ${wl}$libdir'
+-	hardcode_libdir_separator_F77=:
+-
+-	case $host_cpu in
+-	hppa*64*|ia64*)
+-	  hardcode_direct_F77=no
+-	  hardcode_shlibpath_var_F77=no
+-	  ;;
+-	*)
+-	  hardcode_direct_F77=yes
+-	  hardcode_direct_absolute_F77=yes
+-	  export_dynamic_flag_spec_F77='${wl}-E'
+-
+-	  # hardcode_minus_L: Not really in the search PATH,
+-	  # but as the default location of the library.
+-	  hardcode_minus_L_F77=yes
+-	  ;;
+-	esac
+-      fi
+-      ;;
+-
+-    irix5* | irix6* | nonstopux*)
+-      if test "$GCC" = yes; then
+-	archive_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
+-	# Try to use the -exported_symbol ld option, if it does not
+-	# work, assume that -exports_file does not work either and
+-	# implicitly export all symbols.
+-	# This should be the same for all languages, so no per-tag cache variable.
+-	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the $host_os linker accepts -exported_symbol" >&5
+-$as_echo_n "checking whether the $host_os linker accepts -exported_symbol... " >&6; }
+-if ${lt_cv_irix_exported_symbol+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  save_LDFLAGS="$LDFLAGS"
+-	   LDFLAGS="$LDFLAGS -shared ${wl}-exported_symbol ${wl}foo ${wl}-update_registry ${wl}/dev/null"
+-	   cat > conftest.$ac_ext <<_ACEOF
+-
+-      subroutine foo
+-      end
+-_ACEOF
+-if ac_fn_f77_try_link "$LINENO"; then :
+-  lt_cv_irix_exported_symbol=yes
+-else
+-  lt_cv_irix_exported_symbol=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-           LDFLAGS="$save_LDFLAGS"
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_irix_exported_symbol" >&5
+-$as_echo "$lt_cv_irix_exported_symbol" >&6; }
+-	if test "$lt_cv_irix_exported_symbol" = yes; then
+-          archive_expsym_cmds_F77='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations ${wl}-exports_file ${wl}$export_symbols -o $lib'
+-	fi
+-      else
+-	archive_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
+-	archive_expsym_cmds_F77='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -exports_file $export_symbols -o $lib'
+-      fi
+-      archive_cmds_need_lc_F77='no'
+-      hardcode_libdir_flag_spec_F77='${wl}-rpath ${wl}$libdir'
+-      hardcode_libdir_separator_F77=:
+-      inherit_rpath_F77=yes
+-      link_all_deplibs_F77=yes
+-      ;;
+-
+-    netbsd*)
+-      if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+-	archive_cmds_F77='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
+-      else
+-	archive_cmds_F77='$LD -shared -o $lib $libobjs $deplibs $linker_flags'      # ELF
+-      fi
+-      hardcode_libdir_flag_spec_F77='-R$libdir'
+-      hardcode_direct_F77=yes
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    newsos6)
+-      archive_cmds_F77='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-      hardcode_direct_F77=yes
+-      hardcode_libdir_flag_spec_F77='${wl}-rpath ${wl}$libdir'
+-      hardcode_libdir_separator_F77=:
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    *nto* | *qnx*)
+-      ;;
+-
+-    openbsd*)
+-      if test -f /usr/libexec/ld.so; then
+-	hardcode_direct_F77=yes
+-	hardcode_shlibpath_var_F77=no
+-	hardcode_direct_absolute_F77=yes
+-	if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
+-	  archive_cmds_F77='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
+-	  archive_expsym_cmds_F77='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags ${wl}-retain-symbols-file,$export_symbols'
+-	  hardcode_libdir_flag_spec_F77='${wl}-rpath,$libdir'
+-	  export_dynamic_flag_spec_F77='${wl}-E'
+-	else
+-	  case $host_os in
+-	   openbsd[01].* | openbsd2.[0-7] | openbsd2.[0-7].*)
+-	     archive_cmds_F77='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'
+-	     hardcode_libdir_flag_spec_F77='-R$libdir'
+-	     ;;
+-	   *)
+-	     archive_cmds_F77='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
+-	     hardcode_libdir_flag_spec_F77='${wl}-rpath,$libdir'
+-	     ;;
+-	  esac
+-	fi
+-      else
+-	ld_shlibs_F77=no
+-      fi
+-      ;;
+-
+-    os2*)
+-      hardcode_libdir_flag_spec_F77='-L$libdir'
+-      hardcode_minus_L_F77=yes
+-      allow_undefined_flag_F77=unsupported
+-      archive_cmds_F77='$ECHO "LIBRARY $libname INITINSTANCE" > $output_objdir/$libname.def~$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~echo DATA >> $output_objdir/$libname.def~echo " SINGLE NONSHARED" >> $output_objdir/$libname.def~echo EXPORTS >> $output_objdir/$libname.def~emxexp $libobjs >> $output_objdir/$libname.def~$CC -Zdll -Zcrtdll -o $lib $libobjs $deplibs $compiler_flags $output_objdir/$libname.def'
+-      old_archive_from_new_cmds_F77='emximp -o $output_objdir/$libname.a $output_objdir/$libname.def'
+-      ;;
+-
+-    osf3*)
+-      if test "$GCC" = yes; then
+-	allow_undefined_flag_F77=' ${wl}-expect_unresolved ${wl}\*'
+-	archive_cmds_F77='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
+-      else
+-	allow_undefined_flag_F77=' -expect_unresolved \*'
+-	archive_cmds_F77='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
+-      fi
+-      archive_cmds_need_lc_F77='no'
+-      hardcode_libdir_flag_spec_F77='${wl}-rpath ${wl}$libdir'
+-      hardcode_libdir_separator_F77=:
+-      ;;
+-
+-    osf4* | osf5*)	# as osf3* with the addition of -msym flag
+-      if test "$GCC" = yes; then
+-	allow_undefined_flag_F77=' ${wl}-expect_unresolved ${wl}\*'
+-	archive_cmds_F77='$CC -shared${allow_undefined_flag} $pic_flag $libobjs $deplibs $compiler_flags ${wl}-msym ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
+-	hardcode_libdir_flag_spec_F77='${wl}-rpath ${wl}$libdir'
+-      else
+-	allow_undefined_flag_F77=' -expect_unresolved \*'
+-	archive_cmds_F77='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
+-	archive_expsym_cmds_F77='for i in `cat $export_symbols`; do printf "%s %s\\n" -exported_symbol "\$i" >> $lib.exp; done; printf "%s\\n" "-hidden">> $lib.exp~
+-	$CC -shared${allow_undefined_flag} ${wl}-input ${wl}$lib.exp $compiler_flags $libobjs $deplibs -soname $soname `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib~$RM $lib.exp'
+-
+-	# Both c and cxx compiler support -rpath directly
+-	hardcode_libdir_flag_spec_F77='-rpath $libdir'
+-      fi
+-      archive_cmds_need_lc_F77='no'
+-      hardcode_libdir_separator_F77=:
+-      ;;
+-
+-    solaris*)
+-      no_undefined_flag_F77=' -z defs'
+-      if test "$GCC" = yes; then
+-	wlarc='${wl}'
+-	archive_cmds_F77='$CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds_F77='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-M ${wl}$lib.exp ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+-      else
+-	case `$CC -V 2>&1` in
+-	*"Compilers 5.0"*)
+-	  wlarc=''
+-	  archive_cmds_F77='$LD -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-	  archive_expsym_cmds_F77='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $LD -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $linker_flags~$RM $lib.exp'
+-	  ;;
+-	*)
+-	  wlarc='${wl}'
+-	  archive_cmds_F77='$CC -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $compiler_flags'
+-	  archive_expsym_cmds_F77='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
+-	  $CC -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
+-	  ;;
+-	esac
+-      fi
+-      hardcode_libdir_flag_spec_F77='-R$libdir'
+-      hardcode_shlibpath_var_F77=no
+-      case $host_os in
+-      solaris2.[0-5] | solaris2.[0-5].*) ;;
+-      *)
+-	# The compiler driver will combine and reorder linker options,
+-	# but understands `-z linker_flag'.  GCC discards it without `$wl',
+-	# but is careful enough not to reorder.
+-	# Supported since Solaris 2.6 (maybe 2.5.1?)
+-	if test "$GCC" = yes; then
+-	  whole_archive_flag_spec_F77='${wl}-z ${wl}allextract$convenience ${wl}-z ${wl}defaultextract'
+-	else
+-	  whole_archive_flag_spec_F77='-z allextract$convenience -z defaultextract'
+-	fi
+-	;;
+-      esac
+-      link_all_deplibs_F77=yes
+-      ;;
+-
+-    sunos4*)
+-      if test "x$host_vendor" = xsequent; then
+-	# Use $CC to link under sequent, because it throws in some extra .o
+-	# files that make .init and .fini sections work.
+-	archive_cmds_F77='$CC -G ${wl}-h $soname -o $lib $libobjs $deplibs $compiler_flags'
+-      else
+-	archive_cmds_F77='$LD -assert pure-text -Bstatic -o $lib $libobjs $deplibs $linker_flags'
+-      fi
+-      hardcode_libdir_flag_spec_F77='-L$libdir'
+-      hardcode_direct_F77=yes
+-      hardcode_minus_L_F77=yes
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    sysv4)
+-      case $host_vendor in
+-	sni)
+-	  archive_cmds_F77='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-	  hardcode_direct_F77=yes # is this really true???
+-	;;
+-	siemens)
+-	  ## LD is ld it makes a PLAMLIB
+-	  ## CC just makes a GrossModule.
+-	  archive_cmds_F77='$LD -G -o $lib $libobjs $deplibs $linker_flags'
+-	  reload_cmds_F77='$CC -r -o $output$reload_objs'
+-	  hardcode_direct_F77=no
+-        ;;
+-	motorola)
+-	  archive_cmds_F77='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-	  hardcode_direct_F77=no #Motorola manual says yes, but my tests say they lie
+-	;;
+-      esac
+-      runpath_var='LD_RUN_PATH'
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    sysv4.3*)
+-      archive_cmds_F77='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-      hardcode_shlibpath_var_F77=no
+-      export_dynamic_flag_spec_F77='-Bexport'
+-      ;;
+-
+-    sysv4*MP*)
+-      if test -d /usr/nec; then
+-	archive_cmds_F77='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-	hardcode_shlibpath_var_F77=no
+-	runpath_var=LD_RUN_PATH
+-	hardcode_runpath_var=yes
+-	ld_shlibs_F77=yes
+-      fi
+-      ;;
+-
+-    sysv4*uw2* | sysv5OpenUNIX* | sysv5UnixWare7.[01].[10]* | unixware7* | sco3.2v5.0.[024]*)
+-      no_undefined_flag_F77='${wl}-z,text'
+-      archive_cmds_need_lc_F77=no
+-      hardcode_shlibpath_var_F77=no
+-      runpath_var='LD_RUN_PATH'
+-
+-      if test "$GCC" = yes; then
+-	archive_cmds_F77='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds_F77='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-      else
+-	archive_cmds_F77='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds_F77='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-      fi
+-      ;;
+-
+-    sysv5* | sco3.2v5* | sco5v6*)
+-      # Note: We can NOT use -z defs as we might desire, because we do not
+-      # link with -lc, and that would cause any symbols used from libc to
+-      # always be unresolved, which means just about no library would
+-      # ever link correctly.  If we're not using GNU ld we use -z text
+-      # though, which does catch some bad symbols but isn't as heavy-handed
+-      # as -z defs.
+-      no_undefined_flag_F77='${wl}-z,text'
+-      allow_undefined_flag_F77='${wl}-z,nodefs'
+-      archive_cmds_need_lc_F77=no
+-      hardcode_shlibpath_var_F77=no
+-      hardcode_libdir_flag_spec_F77='${wl}-R,$libdir'
+-      hardcode_libdir_separator_F77=':'
+-      link_all_deplibs_F77=yes
+-      export_dynamic_flag_spec_F77='${wl}-Bexport'
+-      runpath_var='LD_RUN_PATH'
+-
+-      if test "$GCC" = yes; then
+-	archive_cmds_F77='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds_F77='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-      else
+-	archive_cmds_F77='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-	archive_expsym_cmds_F77='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
+-      fi
+-      ;;
+-
+-    uts4*)
+-      archive_cmds_F77='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
+-      hardcode_libdir_flag_spec_F77='-L$libdir'
+-      hardcode_shlibpath_var_F77=no
+-      ;;
+-
+-    *)
+-      ld_shlibs_F77=no
+-      ;;
+-    esac
+-
+-    if test x$host_vendor = xsni; then
+-      case $host in
+-      sysv4 | sysv4.2uw2* | sysv4.3* | sysv5*)
+-	export_dynamic_flag_spec_F77='${wl}-Blargedynsym'
+-	;;
+-      esac
+-    fi
+-  fi
+-
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ld_shlibs_F77" >&5
+-$as_echo "$ld_shlibs_F77" >&6; }
+-test "$ld_shlibs_F77" = no && can_build_shared=no
+-
+-with_gnu_ld_F77=$with_gnu_ld
+-
+-
+-
+-
+-
+-
+-#
+-# Do we need to explicitly link libc?
+-#
+-case "x$archive_cmds_need_lc_F77" in
+-x|xyes)
+-  # Assume -lc should be added
+-  archive_cmds_need_lc_F77=yes
+-
+-  if test "$enable_shared" = yes && test "$GCC" = yes; then
+-    case $archive_cmds_F77 in
+-    *'~'*)
+-      # FIXME: we may have to deal with multi-command sequences.
+-      ;;
+-    '$CC '*)
+-      # Test whether the compiler implicitly links with -lc since on some
+-      # systems, -lgcc has to come before -lc. If gcc already passes -lc
+-      # to ld, don't add -lc before -lgcc.
+-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether -lc should be explicitly linked in" >&5
+-$as_echo_n "checking whether -lc should be explicitly linked in... " >&6; }
+-if ${lt_cv_archive_cmds_need_lc_F77+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  $RM conftest*
+-	echo "$lt_simple_compile_test_code" > conftest.$ac_ext
+-
+-	if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
+-  (eval $ac_compile) 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; } 2>conftest.err; then
+-	  soname=conftest
+-	  lib=conftest
+-	  libobjs=conftest.$ac_objext
+-	  deplibs=
+-	  wl=$lt_prog_compiler_wl_F77
+-	  pic_flag=$lt_prog_compiler_pic_F77
+-	  compiler_flags=-v
+-	  linker_flags=-v
+-	  verstring=
+-	  output_objdir=.
+-	  libname=conftest
+-	  lt_save_allow_undefined_flag=$allow_undefined_flag_F77
+-	  allow_undefined_flag_F77=
+-	  if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$archive_cmds_F77 2\>\&1 \| $GREP \" -lc \" \>/dev/null 2\>\&1\""; } >&5
+-  (eval $archive_cmds_F77 2\>\&1 \| $GREP \" -lc \" \>/dev/null 2\>\&1) 2>&5
+-  ac_status=$?
+-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+-  test $ac_status = 0; }
+-	  then
+-	    lt_cv_archive_cmds_need_lc_F77=no
+-	  else
+-	    lt_cv_archive_cmds_need_lc_F77=yes
+-	  fi
+-	  allow_undefined_flag_F77=$lt_save_allow_undefined_flag
+-	else
+-	  cat conftest.err 1>&5
+-	fi
+-	$RM conftest*
+-
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_archive_cmds_need_lc_F77" >&5
+-$as_echo "$lt_cv_archive_cmds_need_lc_F77" >&6; }
+-      archive_cmds_need_lc_F77=$lt_cv_archive_cmds_need_lc_F77
+-      ;;
+-    esac
+-  fi
+-  ;;
+-esac
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking dynamic linker characteristics" >&5
+-$as_echo_n "checking dynamic linker characteristics... " >&6; }
+-
+-library_names_spec=
+-libname_spec='lib$name'
+-soname_spec=
+-shrext_cmds=".so"
+-postinstall_cmds=
+-postuninstall_cmds=
+-finish_cmds=
+-finish_eval=
+-shlibpath_var=
+-shlibpath_overrides_runpath=unknown
+-version_type=none
+-dynamic_linker="$host_os ld.so"
+-sys_lib_dlsearch_path_spec="/lib /usr/lib"
+-need_lib_prefix=unknown
+-hardcode_into_libs=no
+-
+-# when you set need_version to no, make sure it does not cause -set_version
+-# flags to be left without arguments
+-need_version=unknown
+-
+-case $host_os in
+-aix3*)
+-  version_type=linux
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix $libname.a'
+-  shlibpath_var=LIBPATH
+-
+-  # AIX 3 has no versioning support, so we append a major version to the name.
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  ;;
+-
+-aix[4-9]*)
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  hardcode_into_libs=yes
+-  if test "$host_cpu" = ia64; then
+-    # AIX 5 supports IA64
+-    library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
+-    shlibpath_var=LD_LIBRARY_PATH
+-  else
+-    # With GCC up to 2.95.x, collect2 would create an import file
+-    # for dependence libraries.  The import file would start with
+-    # the line `#! .'.  This would cause the generated library to
+-    # depend on `.', always an invalid library.  This was fixed in
+-    # development snapshots of GCC prior to 3.0.
+-    case $host_os in
+-      aix4 | aix4.[01] | aix4.[01].*)
+-      if { echo '#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 97)'
+-	   echo ' yes '
+-	   echo '#endif'; } | ${CC} -E - | $GREP yes > /dev/null; then
+-	:
+-      else
+-	can_build_shared=no
+-      fi
+-      ;;
+-    esac
+-    # AIX (on Power*) has no versioning support, so currently we can not hardcode correct
+-    # soname into executable. Probably we can add versioning support to
+-    # collect2, so additional links can be useful in future.
+-    if test "$aix_use_runtimelinking" = yes; then
+-      # If using run time linking (on AIX 4.2 or later) use lib<name>.so
+-      # instead of lib<name>.a to let people know that these are not
+-      # typical AIX shared libraries.
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    else
+-      # We preserve .a as extension for shared libraries through AIX4.2
+-      # and later when we are not doing run time linking.
+-      library_names_spec='${libname}${release}.a $libname.a'
+-      soname_spec='${libname}${release}${shared_ext}$major'
+-    fi
+-    shlibpath_var=LIBPATH
+-  fi
+-  ;;
+-
+-amigaos*)
+-  case $host_cpu in
+-  powerpc)
+-    # Since July 2007 AmigaOS4 officially supports .so libraries.
+-    # When compiling the executable, add -use-dynld -Lsobjs: to the compileline.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    ;;
+-  m68k)
+-    library_names_spec='$libname.ixlibrary $libname.a'
+-    # Create ${libname}_ixlibrary.a entries in /sys/libs.
+-    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([^/]*\)\.ixlibrary$%\1%'\''`; test $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
+-    ;;
+-  esac
+-  ;;
+-
+-beos*)
+-  library_names_spec='${libname}${shared_ext}'
+-  dynamic_linker="$host_os ld.so"
+-  shlibpath_var=LIBRARY_PATH
+-  ;;
+-
+-bsdi[45]*)
+-  version_type=linux
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  finish_cmds='PATH="\$PATH:/sbin" ldconfig $libdir'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  sys_lib_search_path_spec="/shlib /usr/lib /usr/X11/lib /usr/contrib/lib /lib /usr/local/lib"
+-  sys_lib_dlsearch_path_spec="/shlib /usr/lib /usr/local/lib"
+-  # the default ld.so.conf also contains /usr/contrib/lib and
+-  # /usr/X11R6/lib (/usr/X11 is a link to /usr/X11R6), but let us allow
+-  # libtool to hard-code these into programs
+-  ;;
+-
+-cygwin* | mingw* | pw32* | cegcc*)
+-  version_type=windows
+-  shrext_cmds=".dll"
+-  need_version=no
+-  need_lib_prefix=no
+-
+-  case $GCC,$cc_basename in
+-  yes,*)
+-    # gcc
+-    library_names_spec='$libname.dll.a'
+-    # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
+-      dldir=$destdir/`dirname \$dlpath`~
+-      test -d \$dldir || mkdir -p \$dldir~
+-      $install_prog $dir/$dlname \$dldir/$dlname~
+-      chmod a+x \$dldir/$dlname~
+-      if test -n '\''$stripme'\'' && test -n '\''$striplib'\''; then
+-        eval '\''$striplib \$dldir/$dlname'\'' || exit \$?;
+-      fi'
+-    postuninstall_cmds='dldll=`$SHELL 2>&1 -c '\''. $file; echo \$dlname'\''`~
+-      dlpath=$dir/\$dldll~
+-       $RM \$dlpath'
+-    shlibpath_overrides_runpath=yes
+-
+-    case $host_os in
+-    cygwin*)
+-      # Cygwin DLLs use 'cyg' prefix rather than 'lib'
+-      soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+-
+-      ;;
+-    mingw* | cegcc*)
+-      # MinGW DLLs use traditional 'lib' prefix
+-      soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+-      ;;
+-    pw32*)
+-      # pw32 DLLs use 'pw' prefix rather than 'lib'
+-      library_names_spec='`echo ${libname} | sed -e 's/^lib/pw/'``echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+-      ;;
+-    esac
+-    dynamic_linker='Win32 ld.exe'
+-    ;;
+-
+-  *,cl*)
+-    # Native MSVC
+-    libname_spec='$name'
+-    soname_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext}'
+-    library_names_spec='${libname}.dll.lib'
+-
+-    case $build_os in
+-    mingw*)
+-      sys_lib_search_path_spec=
+-      lt_save_ifs=$IFS
+-      IFS=';'
+-      for lt_path in $LIB
+-      do
+-        IFS=$lt_save_ifs
+-        # Let DOS variable expansion print the short 8.3 style file name.
+-        lt_path=`cd "$lt_path" 2>/dev/null && cmd //C "for %i in (".") do @echo %~si"`
+-        sys_lib_search_path_spec="$sys_lib_search_path_spec $lt_path"
+-      done
+-      IFS=$lt_save_ifs
+-      # Convert to MSYS style.
+-      sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | sed -e 's|\\\\|/|g' -e 's| \\([a-zA-Z]\\):| /\\1|g' -e 's|^ ||'`
+-      ;;
+-    cygwin*)
+-      # Convert to unix form, then to dos form, then back to unix form
+-      # but this time dos style (no spaces!) so that the unix form looks
+-      # like /cygdrive/c/PROGRA~1:/cygdr...
+-      sys_lib_search_path_spec=`cygpath --path --unix "$LIB"`
+-      sys_lib_search_path_spec=`cygpath --path --dos "$sys_lib_search_path_spec" 2>/dev/null`
+-      sys_lib_search_path_spec=`cygpath --path --unix "$sys_lib_search_path_spec" | $SED -e "s/$PATH_SEPARATOR/ /g"`
+-      ;;
+-    *)
+-      sys_lib_search_path_spec="$LIB"
+-      if $ECHO "$sys_lib_search_path_spec" | $GREP ';[c-zC-Z]:/' >/dev/null; then
+-        # It is most probably a Windows format PATH.
+-        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | $SED -e 's/;/ /g'`
+-      else
+-        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | $SED -e "s/$PATH_SEPARATOR/ /g"`
+-      fi
+-      # FIXME: find the short name or the path components, as spaces are
+-      # common. (e.g. "Program Files" -> "PROGRA~1")
+-      ;;
+-    esac
+-
+-    # DLL is installed to $(libdir)/../bin by postinstall_cmds
+-    postinstall_cmds='base_file=`basename \${file}`~
+-      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
+-      dldir=$destdir/`dirname \$dlpath`~
+-      test -d \$dldir || mkdir -p \$dldir~
+-      $install_prog $dir/$dlname \$dldir/$dlname'
+-    postuninstall_cmds='dldll=`$SHELL 2>&1 -c '\''. $file; echo \$dlname'\''`~
+-      dlpath=$dir/\$dldll~
+-       $RM \$dlpath'
+-    shlibpath_overrides_runpath=yes
+-    dynamic_linker='Win32 link.exe'
+-    ;;
+-
+-  *)
+-    # Assume MSVC wrapper
+-    library_names_spec='${libname}`echo ${release} | $SED -e 's/[.]/-/g'`${versuffix}${shared_ext} $libname.lib'
+-    dynamic_linker='Win32 ld.exe'
+-    ;;
+-  esac
+-  # FIXME: first we should search . and the directory the executable is in
+-  shlibpath_var=PATH
+-  ;;
+-
+-darwin* | rhapsody*)
+-  dynamic_linker="$host_os dyld"
+-  version_type=darwin
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${major}$shared_ext ${libname}$shared_ext'
+-  soname_spec='${libname}${release}${major}$shared_ext'
+-  shlibpath_overrides_runpath=yes
+-  shlibpath_var=DYLD_LIBRARY_PATH
+-  shrext_cmds='`test .$module = .yes && echo .so || echo .dylib`'
+-
+-  sys_lib_dlsearch_path_spec='/usr/local/lib /lib /usr/lib'
+-  ;;
+-
+-dgux*)
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname$shared_ext'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  ;;
+-
+-freebsd1*)
+-  dynamic_linker=no
+-  ;;
+-
+-freebsd* | dragonfly*)
+-  # DragonFly does not have aout.  When/if they implement a new
+-  # versioning mechanism, adjust this.
+-  if test -x /usr/bin/objformat; then
+-    objformat=`/usr/bin/objformat`
+-  else
+-    case $host_os in
+-    freebsd[123]*) objformat=aout ;;
+-    *) objformat=elf ;;
+-    esac
+-  fi
+-  version_type=freebsd-$objformat
+-  case $version_type in
+-    freebsd-elf*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
+-      need_version=no
+-      need_lib_prefix=no
+-      ;;
+-    freebsd-*)
+-      library_names_spec='${libname}${release}${shared_ext}$versuffix $libname${shared_ext}$versuffix'
+-      need_version=yes
+-      ;;
+-  esac
+-  shlibpath_var=LD_LIBRARY_PATH
+-  case $host_os in
+-  freebsd2*)
+-    shlibpath_overrides_runpath=yes
+-    ;;
+-  freebsd3.[01]* | freebsdelf3.[01]*)
+-    shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
+-    ;;
+-  freebsd3.[2-9]* | freebsdelf3.[2-9]* | \
+-  freebsd4.[0-5] | freebsdelf4.[0-5] | freebsd4.1.1 | freebsdelf4.1.1)
+-    shlibpath_overrides_runpath=no
+-    hardcode_into_libs=yes
+-    ;;
+-  *) # from 4.6 on, and DragonFly
+-    shlibpath_overrides_runpath=yes
+-    hardcode_into_libs=yes
+-    ;;
+-  esac
+-  ;;
+-
+-gnu*)
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  hardcode_into_libs=yes
+-  ;;
+-
+-haiku*)
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  dynamic_linker="$host_os runtime_loader"
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
+-  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
+-  hardcode_into_libs=yes
+-  ;;
+-
+-hpux9* | hpux10* | hpux11*)
+-  # Give a soname corresponding to the major version so that dld.sl refuses to
+-  # link against other versions.
+-  version_type=sunos
+-  need_lib_prefix=no
+-  need_version=no
+-  case $host_cpu in
+-  ia64*)
+-    shrext_cmds='.so'
+-    hardcode_into_libs=yes
+-    dynamic_linker="$host_os dld.so"
+-    shlibpath_var=LD_LIBRARY_PATH
+-    shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
+-    if test "X$HPUX_IA64_MODE" = X32; then
+-      sys_lib_search_path_spec="/usr/lib/hpux32 /usr/local/lib/hpux32 /usr/local/lib"
+-    else
+-      sys_lib_search_path_spec="/usr/lib/hpux64 /usr/local/lib/hpux64"
+-    fi
+-    sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+-    ;;
+-  hppa*64*)
+-    shrext_cmds='.sl'
+-    hardcode_into_libs=yes
+-    dynamic_linker="$host_os dld.sl"
+-    shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
+-    shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
+-    sys_lib_search_path_spec="/usr/lib/pa20_64 /usr/ccs/lib/pa20_64"
+-    sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
+-    ;;
+-  *)
+-    shrext_cmds='.sl'
+-    dynamic_linker="$host_os dld.sl"
+-    shlibpath_var=SHLIB_PATH
+-    shlibpath_overrides_runpath=no # +s is required to enable SHLIB_PATH
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
+-    ;;
+-  esac
+-  # HP-UX runs *really* slowly unless shared libraries are mode 555, ...
+-  postinstall_cmds='chmod 555 $lib'
+-  # or fails outright, so override atomically:
+-  install_override_mode=555
+-  ;;
+-
+-interix[3-9]*)
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
+-  ;;
+-
+-irix5* | irix6* | nonstopux*)
+-  case $host_os in
+-    nonstopux*) version_type=nonstopux ;;
+-    *)
+-	if test "$lt_cv_prog_gnu_ld" = yes; then
+-		version_type=linux
+-	else
+-		version_type=irix
+-	fi ;;
+-  esac
+-  need_lib_prefix=no
+-  need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext} $libname${shared_ext}'
+-  case $host_os in
+-  irix5* | nonstopux*)
+-    libsuff= shlibsuff=
+-    ;;
+-  *)
+-    case $LD in # libtool.m4 will add one of these switches to LD
+-    *-32|*"-32 "|*-melf32bsmip|*"-melf32bsmip ")
+-      libsuff= shlibsuff= libmagic=32-bit;;
+-    *-n32|*"-n32 "|*-melf32bmipn32|*"-melf32bmipn32 ")
+-      libsuff=32 shlibsuff=N32 libmagic=N32;;
+-    *-64|*"-64 "|*-melf64bmip|*"-melf64bmip ")
+-      libsuff=64 shlibsuff=64 libmagic=64-bit;;
+-    *) libsuff= shlibsuff= libmagic=never-match;;
+-    esac
+-    ;;
+-  esac
+-  shlibpath_var=LD_LIBRARY${shlibsuff}_PATH
+-  shlibpath_overrides_runpath=no
+-  sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
+-  sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
+-  hardcode_into_libs=yes
+-  ;;
+-
+-# No shared lib support for Linux oldld, aout, or coff.
+-linux*oldld* | linux*aout* | linux*coff*)
+-  dynamic_linker=no
+-  ;;
+-
+-# This must be Linux ELF.
+-linux* | k*bsd*-gnu | kopensolaris*-gnu)
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=no
+-
+-  # Some binutils ld are patched to set DT_RUNPATH
+-  if ${lt_cv_shlibpath_overrides_runpath+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-  lt_cv_shlibpath_overrides_runpath=no
+-    save_LDFLAGS=$LDFLAGS
+-    save_libdir=$libdir
+-    eval "libdir=/foo; wl=\"$lt_prog_compiler_wl_F77\"; \
+-	 LDFLAGS=\"\$LDFLAGS $hardcode_libdir_flag_spec_F77\""
+-    cat > conftest.$ac_ext <<_ACEOF
+-      program main
+-
+-      end
+-_ACEOF
+-if ac_fn_f77_try_link "$LINENO"; then :
+-  if  ($OBJDUMP -p conftest$ac_exeext) 2>/dev/null | grep "RUNPATH.*$libdir" >/dev/null; then :
+-  lt_cv_shlibpath_overrides_runpath=yes
+-fi
+-fi
+-rm -f core conftest.err conftest.$ac_objext \
+-    conftest$ac_exeext conftest.$ac_ext
+-    LDFLAGS=$save_LDFLAGS
+-    libdir=$save_libdir
+-
+-fi
+-
+-  shlibpath_overrides_runpath=$lt_cv_shlibpath_overrides_runpath
+-
+-  # This implies no fast_install, which is unacceptable.
+-  # Some rework will be needed to allow for fast_install
+-  # before this can be enabled.
+-  hardcode_into_libs=yes
+-
+-  # Append ld.so.conf contents to the search path
+-  if test -f /etc/ld.so.conf; then
+-    lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \$2)); skip = 1; } { if (!skip) print \$0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
+-    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
+-  fi
+-
+-  # We used to test for /lib/ld.so.1 and disable shared libraries on
+-  # powerpc, because MkLinux only supported shared libraries with the
+-  # GNU dynamic linker.  Since this was broken with cross compilers,
+-  # most powerpc-linux boxes support dynamic linking these days and
+-  # people can always --disable-shared, the test was removed, and we
+-  # assume the GNU/Linux dynamic linker is in use.
+-  dynamic_linker='GNU/Linux ld.so'
+-  ;;
+-
+-netbsd*)
+-  version_type=sunos
+-  need_lib_prefix=no
+-  need_version=no
+-  if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
+-    finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+-    dynamic_linker='NetBSD (a.out) ld.so'
+-  else
+-    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
+-    soname_spec='${libname}${release}${shared_ext}$major'
+-    dynamic_linker='NetBSD ld.elf_so'
+-  fi
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
+-  ;;
+-
+-newsos6)
+-  version_type=linux
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
+-  ;;
+-
+-*nto* | *qnx*)
+-  version_type=qnx
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
+-  dynamic_linker='ldqnx.so'
+-  ;;
+-
+-openbsd*)
+-  version_type=sunos
+-  sys_lib_dlsearch_path_spec="/usr/lib"
+-  need_lib_prefix=no
+-  # Some older versions of OpenBSD (3.3 at least) *do* need versioned libs.
+-  case $host_os in
+-    openbsd3.3 | openbsd3.3.*)	need_version=yes ;;
+-    *)				need_version=no  ;;
+-  esac
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
+-  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
+-    case $host_os in
+-      openbsd2.[89] | openbsd2.[89].*)
+-	shlibpath_overrides_runpath=no
+-	;;
+-      *)
+-	shlibpath_overrides_runpath=yes
+-	;;
+-      esac
+-  else
+-    shlibpath_overrides_runpath=yes
+-  fi
+-  ;;
+-
+-os2*)
+-  libname_spec='$name'
+-  shrext_cmds=".dll"
+-  need_lib_prefix=no
+-  library_names_spec='$libname${shared_ext} $libname.a'
+-  dynamic_linker='OS/2 ld.exe'
+-  shlibpath_var=LIBPATH
+-  ;;
+-
+-osf3* | osf4* | osf5*)
+-  version_type=osf
+-  need_lib_prefix=no
+-  need_version=no
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  sys_lib_search_path_spec="/usr/shlib /usr/ccs/lib /usr/lib/cmplrs/cc /usr/lib /usr/local/lib /var/shlib"
+-  sys_lib_dlsearch_path_spec="$sys_lib_search_path_spec"
+-  ;;
+-
+-rdos*)
+-  dynamic_linker=no
+-  ;;
+-
+-solaris*)
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
+-  # ldd complains unless libraries are executable
+-  postinstall_cmds='chmod +x $lib'
+-  ;;
+-
+-sunos4*)
+-  version_type=sunos
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
+-  finish_cmds='PATH="\$PATH:/usr/etc" ldconfig $libdir'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
+-  if test "$with_gnu_ld" = yes; then
+-    need_lib_prefix=no
+-  fi
+-  need_version=yes
+-  ;;
+-
+-sysv4 | sysv4.3*)
+-  version_type=linux
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  case $host_vendor in
+-    sni)
+-      shlibpath_overrides_runpath=no
+-      need_lib_prefix=no
+-      runpath_var=LD_RUN_PATH
+-      ;;
+-    siemens)
+-      need_lib_prefix=no
+-      ;;
+-    motorola)
+-      need_lib_prefix=no
+-      need_version=no
+-      shlibpath_overrides_runpath=no
+-      sys_lib_search_path_spec='/lib /usr/lib /usr/ccs/lib'
+-      ;;
+-  esac
+-  ;;
+-
+-sysv4*MP*)
+-  if test -d /usr/nec ;then
+-    version_type=linux
+-    library_names_spec='$libname${shared_ext}.$versuffix $libname${shared_ext}.$major $libname${shared_ext}'
+-    soname_spec='$libname${shared_ext}.$major'
+-    shlibpath_var=LD_LIBRARY_PATH
+-  fi
+-  ;;
+-
+-sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
+-  version_type=freebsd-elf
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=yes
+-  hardcode_into_libs=yes
+-  if test "$with_gnu_ld" = yes; then
+-    sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
+-  else
+-    sys_lib_search_path_spec='/usr/ccs/lib /usr/lib'
+-    case $host_os in
+-      sco3.2v5*)
+-        sys_lib_search_path_spec="$sys_lib_search_path_spec /lib"
+-	;;
+-    esac
+-  fi
+-  sys_lib_dlsearch_path_spec='/usr/lib'
+-  ;;
+-
+-tpf*)
+-  # TPF is a cross-target only.  Preferred cross-host = GNU/Linux.
+-  version_type=linux
+-  need_lib_prefix=no
+-  need_version=no
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  shlibpath_overrides_runpath=no
+-  hardcode_into_libs=yes
+-  ;;
+-
+-uts4*)
+-  version_type=linux
+-  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
+-  soname_spec='${libname}${release}${shared_ext}$major'
+-  shlibpath_var=LD_LIBRARY_PATH
+-  ;;
+-
+-*)
+-  dynamic_linker=no
+-  ;;
+-esac
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $dynamic_linker" >&5
+-$as_echo "$dynamic_linker" >&6; }
+-test "$dynamic_linker" = no && can_build_shared=no
+-
+-variables_saved_for_relink="PATH $shlibpath_var $runpath_var"
+-if test "$GCC" = yes; then
+-  variables_saved_for_relink="$variables_saved_for_relink GCC_EXEC_PREFIX COMPILER_PATH LIBRARY_PATH"
+-fi
+-
+-if test "${lt_cv_sys_lib_search_path_spec+set}" = set; then
+-  sys_lib_search_path_spec="$lt_cv_sys_lib_search_path_spec"
+-fi
+-if test "${lt_cv_sys_lib_dlsearch_path_spec+set}" = set; then
+-  sys_lib_dlsearch_path_spec="$lt_cv_sys_lib_dlsearch_path_spec"
+-fi
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking how to hardcode library paths into programs" >&5
+-$as_echo_n "checking how to hardcode library paths into programs... " >&6; }
+-hardcode_action_F77=
+-if test -n "$hardcode_libdir_flag_spec_F77" ||
+-   test -n "$runpath_var_F77" ||
+-   test "X$hardcode_automatic_F77" = "Xyes" ; then
+-
+-  # We can hardcode non-existent directories.
+-  if test "$hardcode_direct_F77" != no &&
+-     # If the only mechanism to avoid hardcoding is shlibpath_var, we
+-     # have to relink, otherwise we might link with an installed library
+-     # when we should be linking with a yet-to-be-installed one
+-     ## test "$_LT_TAGVAR(hardcode_shlibpath_var, F77)" != no &&
+-     test "$hardcode_minus_L_F77" != no; then
+-    # Linking always hardcodes the temporary library directory.
+-    hardcode_action_F77=relink
+-  else
+-    # We can link without hardcoding, and we can hardcode nonexisting dirs.
+-    hardcode_action_F77=immediate
+-  fi
+-else
+-  # We cannot hardcode anything, or else we can only hardcode existing
+-  # directories.
+-  hardcode_action_F77=unsupported
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $hardcode_action_F77" >&5
+-$as_echo "$hardcode_action_F77" >&6; }
+-
+-if test "$hardcode_action_F77" = relink ||
+-   test "$inherit_rpath_F77" = yes; then
+-  # Fast installation is not supported
+-  enable_fast_install=no
+-elif test "$shlibpath_overrides_runpath" = yes ||
+-     test "$enable_shared" = no; then
+-  # Fast installation is not necessary
+-  enable_fast_install=needless
+-fi
+-
+-
+-
+-
+-
+-
+-
+-  fi # test -n "$compiler"
+-
+-  GCC=$lt_save_GCC
+-  CC="$lt_save_CC"
+-  CFLAGS="$lt_save_CFLAGS"
+-fi # test "$_lt_disable_F77" != yes
+-
+-ac_ext=c
+-ac_cpp='$CPP $CPPFLAGS'
+-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_c_compiler_gnu
+-
+ 
+ 
+ 
+@@ -29562,103 +26900,54 @@
+ postdeps='`$ECHO "$postdeps" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_path='`$ECHO "$compiler_lib_search_path" | $SED "$delay_single_quote_subst"`'
+ LD_CXX='`$ECHO "$LD_CXX" | $SED "$delay_single_quote_subst"`'
+-LD_F77='`$ECHO "$LD_F77" | $SED "$delay_single_quote_subst"`'
+ reload_flag_CXX='`$ECHO "$reload_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-reload_flag_F77='`$ECHO "$reload_flag_F77" | $SED "$delay_single_quote_subst"`'
+ reload_cmds_CXX='`$ECHO "$reload_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-reload_cmds_F77='`$ECHO "$reload_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_cmds_CXX='`$ECHO "$old_archive_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_cmds_F77='`$ECHO "$old_archive_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_CXX='`$ECHO "$compiler_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_F77='`$ECHO "$compiler_F77" | $SED "$delay_single_quote_subst"`'
+ GCC_CXX='`$ECHO "$GCC_CXX" | $SED "$delay_single_quote_subst"`'
+-GCC_F77='`$ECHO "$GCC_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_no_builtin_flag_CXX='`$ECHO "$lt_prog_compiler_no_builtin_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_no_builtin_flag_F77='`$ECHO "$lt_prog_compiler_no_builtin_flag_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_pic_CXX='`$ECHO "$lt_prog_compiler_pic_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_pic_F77='`$ECHO "$lt_prog_compiler_pic_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_wl_CXX='`$ECHO "$lt_prog_compiler_wl_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_wl_F77='`$ECHO "$lt_prog_compiler_wl_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_static_CXX='`$ECHO "$lt_prog_compiler_static_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_static_F77='`$ECHO "$lt_prog_compiler_static_F77" | $SED "$delay_single_quote_subst"`'
+ lt_cv_prog_compiler_c_o_CXX='`$ECHO "$lt_cv_prog_compiler_c_o_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_cv_prog_compiler_c_o_F77='`$ECHO "$lt_cv_prog_compiler_c_o_F77" | $SED "$delay_single_quote_subst"`'
+ archive_cmds_need_lc_CXX='`$ECHO "$archive_cmds_need_lc_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_cmds_need_lc_F77='`$ECHO "$archive_cmds_need_lc_F77" | $SED "$delay_single_quote_subst"`'
+ enable_shared_with_static_runtimes_CXX='`$ECHO "$enable_shared_with_static_runtimes_CXX" | $SED "$delay_single_quote_subst"`'
+-enable_shared_with_static_runtimes_F77='`$ECHO "$enable_shared_with_static_runtimes_F77" | $SED "$delay_single_quote_subst"`'
+ export_dynamic_flag_spec_CXX='`$ECHO "$export_dynamic_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-export_dynamic_flag_spec_F77='`$ECHO "$export_dynamic_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ whole_archive_flag_spec_CXX='`$ECHO "$whole_archive_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-whole_archive_flag_spec_F77='`$ECHO "$whole_archive_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_needs_object_CXX='`$ECHO "$compiler_needs_object_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_needs_object_F77='`$ECHO "$compiler_needs_object_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_from_new_cmds_CXX='`$ECHO "$old_archive_from_new_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_from_new_cmds_F77='`$ECHO "$old_archive_from_new_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_from_expsyms_cmds_CXX='`$ECHO "$old_archive_from_expsyms_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_from_expsyms_cmds_F77='`$ECHO "$old_archive_from_expsyms_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ archive_cmds_CXX='`$ECHO "$archive_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_cmds_F77='`$ECHO "$archive_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ archive_expsym_cmds_CXX='`$ECHO "$archive_expsym_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_expsym_cmds_F77='`$ECHO "$archive_expsym_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ module_cmds_CXX='`$ECHO "$module_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-module_cmds_F77='`$ECHO "$module_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ module_expsym_cmds_CXX='`$ECHO "$module_expsym_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-module_expsym_cmds_F77='`$ECHO "$module_expsym_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ with_gnu_ld_CXX='`$ECHO "$with_gnu_ld_CXX" | $SED "$delay_single_quote_subst"`'
+-with_gnu_ld_F77='`$ECHO "$with_gnu_ld_F77" | $SED "$delay_single_quote_subst"`'
+ allow_undefined_flag_CXX='`$ECHO "$allow_undefined_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-allow_undefined_flag_F77='`$ECHO "$allow_undefined_flag_F77" | $SED "$delay_single_quote_subst"`'
+ no_undefined_flag_CXX='`$ECHO "$no_undefined_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-no_undefined_flag_F77='`$ECHO "$no_undefined_flag_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_flag_spec_CXX='`$ECHO "$hardcode_libdir_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_flag_spec_F77='`$ECHO "$hardcode_libdir_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_flag_spec_ld_CXX='`$ECHO "$hardcode_libdir_flag_spec_ld_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_flag_spec_ld_F77='`$ECHO "$hardcode_libdir_flag_spec_ld_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_separator_CXX='`$ECHO "$hardcode_libdir_separator_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_separator_F77='`$ECHO "$hardcode_libdir_separator_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_direct_CXX='`$ECHO "$hardcode_direct_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_direct_F77='`$ECHO "$hardcode_direct_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_direct_absolute_CXX='`$ECHO "$hardcode_direct_absolute_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_direct_absolute_F77='`$ECHO "$hardcode_direct_absolute_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_minus_L_CXX='`$ECHO "$hardcode_minus_L_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_minus_L_F77='`$ECHO "$hardcode_minus_L_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_shlibpath_var_CXX='`$ECHO "$hardcode_shlibpath_var_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_shlibpath_var_F77='`$ECHO "$hardcode_shlibpath_var_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_automatic_CXX='`$ECHO "$hardcode_automatic_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_automatic_F77='`$ECHO "$hardcode_automatic_F77" | $SED "$delay_single_quote_subst"`'
+ inherit_rpath_CXX='`$ECHO "$inherit_rpath_CXX" | $SED "$delay_single_quote_subst"`'
+-inherit_rpath_F77='`$ECHO "$inherit_rpath_F77" | $SED "$delay_single_quote_subst"`'
+ link_all_deplibs_CXX='`$ECHO "$link_all_deplibs_CXX" | $SED "$delay_single_quote_subst"`'
+-link_all_deplibs_F77='`$ECHO "$link_all_deplibs_F77" | $SED "$delay_single_quote_subst"`'
+ always_export_symbols_CXX='`$ECHO "$always_export_symbols_CXX" | $SED "$delay_single_quote_subst"`'
+-always_export_symbols_F77='`$ECHO "$always_export_symbols_F77" | $SED "$delay_single_quote_subst"`'
+ export_symbols_cmds_CXX='`$ECHO "$export_symbols_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-export_symbols_cmds_F77='`$ECHO "$export_symbols_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ exclude_expsyms_CXX='`$ECHO "$exclude_expsyms_CXX" | $SED "$delay_single_quote_subst"`'
+-exclude_expsyms_F77='`$ECHO "$exclude_expsyms_F77" | $SED "$delay_single_quote_subst"`'
+ include_expsyms_CXX='`$ECHO "$include_expsyms_CXX" | $SED "$delay_single_quote_subst"`'
+-include_expsyms_F77='`$ECHO "$include_expsyms_F77" | $SED "$delay_single_quote_subst"`'
+ prelink_cmds_CXX='`$ECHO "$prelink_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-prelink_cmds_F77='`$ECHO "$prelink_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ postlink_cmds_CXX='`$ECHO "$postlink_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-postlink_cmds_F77='`$ECHO "$postlink_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ file_list_spec_CXX='`$ECHO "$file_list_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-file_list_spec_F77='`$ECHO "$file_list_spec_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_action_CXX='`$ECHO "$hardcode_action_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_action_F77='`$ECHO "$hardcode_action_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_dirs_CXX='`$ECHO "$compiler_lib_search_dirs_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_lib_search_dirs_F77='`$ECHO "$compiler_lib_search_dirs_F77" | $SED "$delay_single_quote_subst"`'
+ predep_objects_CXX='`$ECHO "$predep_objects_CXX" | $SED "$delay_single_quote_subst"`'
+-predep_objects_F77='`$ECHO "$predep_objects_F77" | $SED "$delay_single_quote_subst"`'
+ postdep_objects_CXX='`$ECHO "$postdep_objects_CXX" | $SED "$delay_single_quote_subst"`'
+-postdep_objects_F77='`$ECHO "$postdep_objects_F77" | $SED "$delay_single_quote_subst"`'
+ predeps_CXX='`$ECHO "$predeps_CXX" | $SED "$delay_single_quote_subst"`'
+-predeps_F77='`$ECHO "$predeps_F77" | $SED "$delay_single_quote_subst"`'
+ postdeps_CXX='`$ECHO "$postdeps_CXX" | $SED "$delay_single_quote_subst"`'
+-postdeps_F77='`$ECHO "$postdeps_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_path_CXX='`$ECHO "$compiler_lib_search_path_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_lib_search_path_F77='`$ECHO "$compiler_lib_search_path_F77" | $SED "$delay_single_quote_subst"`'
+ 
+ LTCC='$LTCC'
+ LTCFLAGS='$LTCFLAGS'
+@@ -29746,57 +27035,31 @@
+ postdeps \
+ compiler_lib_search_path \
+ LD_CXX \
+-LD_F77 \
+ reload_flag_CXX \
+-reload_flag_F77 \
+ compiler_CXX \
+-compiler_F77 \
+ lt_prog_compiler_no_builtin_flag_CXX \
+-lt_prog_compiler_no_builtin_flag_F77 \
+ lt_prog_compiler_pic_CXX \
+-lt_prog_compiler_pic_F77 \
+ lt_prog_compiler_wl_CXX \
+-lt_prog_compiler_wl_F77 \
+ lt_prog_compiler_static_CXX \
+-lt_prog_compiler_static_F77 \
+ lt_cv_prog_compiler_c_o_CXX \
+-lt_cv_prog_compiler_c_o_F77 \
+ export_dynamic_flag_spec_CXX \
+-export_dynamic_flag_spec_F77 \
+ whole_archive_flag_spec_CXX \
+-whole_archive_flag_spec_F77 \
+ compiler_needs_object_CXX \
+-compiler_needs_object_F77 \
+ with_gnu_ld_CXX \
+-with_gnu_ld_F77 \
+ allow_undefined_flag_CXX \
+-allow_undefined_flag_F77 \
+ no_undefined_flag_CXX \
+-no_undefined_flag_F77 \
+ hardcode_libdir_flag_spec_CXX \
+-hardcode_libdir_flag_spec_F77 \
+ hardcode_libdir_flag_spec_ld_CXX \
+-hardcode_libdir_flag_spec_ld_F77 \
+ hardcode_libdir_separator_CXX \
+-hardcode_libdir_separator_F77 \
+ exclude_expsyms_CXX \
+-exclude_expsyms_F77 \
+ include_expsyms_CXX \
+-include_expsyms_F77 \
+ file_list_spec_CXX \
+-file_list_spec_F77 \
+ compiler_lib_search_dirs_CXX \
+-compiler_lib_search_dirs_F77 \
+ predep_objects_CXX \
+-predep_objects_F77 \
+ postdep_objects_CXX \
+-postdep_objects_F77 \
+ predeps_CXX \
+-predeps_F77 \
+ postdeps_CXX \
+-postdeps_F77 \
+-compiler_lib_search_path_CXX \
+-compiler_lib_search_path_F77; do
++compiler_lib_search_path_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+       eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\""
+@@ -29828,27 +27091,16 @@
+ sys_lib_search_path_spec \
+ sys_lib_dlsearch_path_spec \
+ reload_cmds_CXX \
+-reload_cmds_F77 \
+ old_archive_cmds_CXX \
+-old_archive_cmds_F77 \
+ old_archive_from_new_cmds_CXX \
+-old_archive_from_new_cmds_F77 \
+ old_archive_from_expsyms_cmds_CXX \
+-old_archive_from_expsyms_cmds_F77 \
+ archive_cmds_CXX \
+-archive_cmds_F77 \
+ archive_expsym_cmds_CXX \
+-archive_expsym_cmds_F77 \
+ module_cmds_CXX \
+-module_cmds_F77 \
+ module_expsym_cmds_CXX \
+-module_expsym_cmds_F77 \
+ export_symbols_cmds_CXX \
+-export_symbols_cmds_F77 \
+ prelink_cmds_CXX \
+-prelink_cmds_F77 \
+-postlink_cmds_CXX \
+-postlink_cmds_F77; do
++postlink_cmds_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+       eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\""
+@@ -29881,8 +27133,6 @@
+ 
+ 
+ 
+-
+-
+ _ACEOF
+ 
+ cat >>$CONFIG_STATUS <<\_ACEOF || ac_write_fail=1
+@@ -30594,7 +27844,7 @@
+ 
+ 
+ # The names of the tagged configurations supported by this script.
+-available_tags="CXX F77 "
++available_tags="CXX "
+ 
+ # ### BEGIN LIBTOOL CONFIG
+ 
+@@ -31348,163 +28598,6 @@
+ # ### END LIBTOOL TAG CONFIG: CXX
+ _LT_EOF
+ 
+-
+-    cat <<_LT_EOF >> "$ofile"
+-
+-# ### BEGIN LIBTOOL TAG CONFIG: F77
+-
+-# The linker used to build libraries.
+-LD=$lt_LD_F77
+-
+-# How to create reloadable object files.
+-reload_flag=$lt_reload_flag_F77
+-reload_cmds=$lt_reload_cmds_F77
+-
+-# Commands used to build an old-style archive.
+-old_archive_cmds=$lt_old_archive_cmds_F77
+-
+-# A language specific compiler.
+-CC=$lt_compiler_F77
+-
+-# Is the compiler the GNU compiler?
+-with_gcc=$GCC_F77
+-
+-# Compiler flag to turn off builtin functions.
+-no_builtin_flag=$lt_lt_prog_compiler_no_builtin_flag_F77
+-
+-# Additional compiler flags for building library objects.
+-pic_flag=$lt_lt_prog_compiler_pic_F77
+-
+-# How to pass a linker flag through the compiler.
+-wl=$lt_lt_prog_compiler_wl_F77
+-
+-# Compiler flag to prevent dynamic linking.
+-link_static_flag=$lt_lt_prog_compiler_static_F77
+-
+-# Does compiler simultaneously support -c and -o options?
+-compiler_c_o=$lt_lt_cv_prog_compiler_c_o_F77
+-
+-# Whether or not to add -lc for building shared libraries.
+-build_libtool_need_lc=$archive_cmds_need_lc_F77
+-
+-# Whether or not to disallow shared libs when runtime libs are static.
+-allow_libtool_libs_with_static_runtimes=$enable_shared_with_static_runtimes_F77
+-
+-# Compiler flag to allow reflexive dlopens.
+-export_dynamic_flag_spec=$lt_export_dynamic_flag_spec_F77
+-
+-# Compiler flag to generate shared objects directly from archives.
+-whole_archive_flag_spec=$lt_whole_archive_flag_spec_F77
+-
+-# Whether the compiler copes with passing no objects directly.
+-compiler_needs_object=$lt_compiler_needs_object_F77
+-
+-# Create an old-style archive from a shared archive.
+-old_archive_from_new_cmds=$lt_old_archive_from_new_cmds_F77
+-
+-# Create a temporary old-style archive to link instead of a shared archive.
+-old_archive_from_expsyms_cmds=$lt_old_archive_from_expsyms_cmds_F77
+-
+-# Commands used to build a shared archive.
+-archive_cmds=$lt_archive_cmds_F77
+-archive_expsym_cmds=$lt_archive_expsym_cmds_F77
+-
+-# Commands used to build a loadable module if different from building
+-# a shared archive.
+-module_cmds=$lt_module_cmds_F77
+-module_expsym_cmds=$lt_module_expsym_cmds_F77
+-
+-# Whether we are building with GNU ld or not.
+-with_gnu_ld=$lt_with_gnu_ld_F77
+-
+-# Flag that allows shared libraries with undefined symbols to be built.
+-allow_undefined_flag=$lt_allow_undefined_flag_F77
+-
+-# Flag that enforces no undefined symbols.
+-no_undefined_flag=$lt_no_undefined_flag_F77
+-
+-# Flag to hardcode \$libdir into a binary during linking.
+-# This must work even if \$libdir does not exist
+-hardcode_libdir_flag_spec=$lt_hardcode_libdir_flag_spec_F77
+-
+-# If ld is used when linking, flag to hardcode \$libdir into a binary
+-# during linking.  This must work even if \$libdir does not exist.
+-hardcode_libdir_flag_spec_ld=$lt_hardcode_libdir_flag_spec_ld_F77
+-
+-# Whether we need a single "-rpath" flag with a separated argument.
+-hardcode_libdir_separator=$lt_hardcode_libdir_separator_F77
+-
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
+-# DIR into the resulting binary.
+-hardcode_direct=$hardcode_direct_F77
+-
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
+-# DIR into the resulting binary and the resulting library dependency is
+-# "absolute",i.e impossible to change by setting \${shlibpath_var} if the
+-# library is relocated.
+-hardcode_direct_absolute=$hardcode_direct_absolute_F77
+-
+-# Set to "yes" if using the -LDIR flag during linking hardcodes DIR
+-# into the resulting binary.
+-hardcode_minus_L=$hardcode_minus_L_F77
+-
+-# Set to "yes" if using SHLIBPATH_VAR=DIR during linking hardcodes DIR
+-# into the resulting binary.
+-hardcode_shlibpath_var=$hardcode_shlibpath_var_F77
+-
+-# Set to "yes" if building a shared library automatically hardcodes DIR
+-# into the library and all subsequent libraries and executables linked
+-# against it.
+-hardcode_automatic=$hardcode_automatic_F77
+-
+-# Set to yes if linker adds runtime paths of dependent libraries
+-# to runtime path list.
+-inherit_rpath=$inherit_rpath_F77
+-
+-# Whether libtool must link a program against all its dependency libraries.
+-link_all_deplibs=$link_all_deplibs_F77
+-
+-# Set to "yes" if exported symbols are required.
+-always_export_symbols=$always_export_symbols_F77
+-
+-# The commands to list exported symbols.
+-export_symbols_cmds=$lt_export_symbols_cmds_F77
+-
+-# Symbols that should not be listed in the preloaded symbols.
+-exclude_expsyms=$lt_exclude_expsyms_F77
+-
+-# Symbols that must always be exported.
+-include_expsyms=$lt_include_expsyms_F77
+-
+-# Commands necessary for linking programs (against libraries) with templates.
+-prelink_cmds=$lt_prelink_cmds_F77
+-
+-# Commands necessary for finishing linking programs.
+-postlink_cmds=$lt_postlink_cmds_F77
+-
+-# Specify filename containing input files.
+-file_list_spec=$lt_file_list_spec_F77
+-
+-# How to hardcode a shared library path into an executable.
+-hardcode_action=$hardcode_action_F77
+-
+-# The directories searched by this compiler when creating a shared library.
+-compiler_lib_search_dirs=$lt_compiler_lib_search_dirs_F77
+-
+-# Dependencies to place before and after the objects being linked to
+-# create a shared library.
+-predep_objects=$lt_predep_objects_F77
+-postdep_objects=$lt_postdep_objects_F77
+-predeps=$lt_predeps_F77
+-postdeps=$lt_postdeps_F77
+-
+-# The library search path used internally by the compiler when linking
+-# a shared library.
+-compiler_lib_search_path=$lt_compiler_lib_search_path_F77
+-
+-# ### END LIBTOOL TAG CONFIG: F77
+-_LT_EOF
+-
+  ;;
+ 
+   esac
+@@ -32583,103 +29676,54 @@
+ postdeps='`$ECHO "$postdeps" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_path='`$ECHO "$compiler_lib_search_path" | $SED "$delay_single_quote_subst"`'
+ LD_CXX='`$ECHO "$LD_CXX" | $SED "$delay_single_quote_subst"`'
+-LD_F77='`$ECHO "$LD_F77" | $SED "$delay_single_quote_subst"`'
+ reload_flag_CXX='`$ECHO "$reload_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-reload_flag_F77='`$ECHO "$reload_flag_F77" | $SED "$delay_single_quote_subst"`'
+ reload_cmds_CXX='`$ECHO "$reload_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-reload_cmds_F77='`$ECHO "$reload_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_cmds_CXX='`$ECHO "$old_archive_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_cmds_F77='`$ECHO "$old_archive_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_CXX='`$ECHO "$compiler_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_F77='`$ECHO "$compiler_F77" | $SED "$delay_single_quote_subst"`'
+ GCC_CXX='`$ECHO "$GCC_CXX" | $SED "$delay_single_quote_subst"`'
+-GCC_F77='`$ECHO "$GCC_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_no_builtin_flag_CXX='`$ECHO "$lt_prog_compiler_no_builtin_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_no_builtin_flag_F77='`$ECHO "$lt_prog_compiler_no_builtin_flag_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_pic_CXX='`$ECHO "$lt_prog_compiler_pic_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_pic_F77='`$ECHO "$lt_prog_compiler_pic_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_wl_CXX='`$ECHO "$lt_prog_compiler_wl_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_wl_F77='`$ECHO "$lt_prog_compiler_wl_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_static_CXX='`$ECHO "$lt_prog_compiler_static_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_static_F77='`$ECHO "$lt_prog_compiler_static_F77" | $SED "$delay_single_quote_subst"`'
+ lt_cv_prog_compiler_c_o_CXX='`$ECHO "$lt_cv_prog_compiler_c_o_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_cv_prog_compiler_c_o_F77='`$ECHO "$lt_cv_prog_compiler_c_o_F77" | $SED "$delay_single_quote_subst"`'
+ archive_cmds_need_lc_CXX='`$ECHO "$archive_cmds_need_lc_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_cmds_need_lc_F77='`$ECHO "$archive_cmds_need_lc_F77" | $SED "$delay_single_quote_subst"`'
+ enable_shared_with_static_runtimes_CXX='`$ECHO "$enable_shared_with_static_runtimes_CXX" | $SED "$delay_single_quote_subst"`'
+-enable_shared_with_static_runtimes_F77='`$ECHO "$enable_shared_with_static_runtimes_F77" | $SED "$delay_single_quote_subst"`'
+ export_dynamic_flag_spec_CXX='`$ECHO "$export_dynamic_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-export_dynamic_flag_spec_F77='`$ECHO "$export_dynamic_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ whole_archive_flag_spec_CXX='`$ECHO "$whole_archive_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-whole_archive_flag_spec_F77='`$ECHO "$whole_archive_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_needs_object_CXX='`$ECHO "$compiler_needs_object_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_needs_object_F77='`$ECHO "$compiler_needs_object_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_from_new_cmds_CXX='`$ECHO "$old_archive_from_new_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_from_new_cmds_F77='`$ECHO "$old_archive_from_new_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_from_expsyms_cmds_CXX='`$ECHO "$old_archive_from_expsyms_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_from_expsyms_cmds_F77='`$ECHO "$old_archive_from_expsyms_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ archive_cmds_CXX='`$ECHO "$archive_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_cmds_F77='`$ECHO "$archive_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ archive_expsym_cmds_CXX='`$ECHO "$archive_expsym_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_expsym_cmds_F77='`$ECHO "$archive_expsym_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ module_cmds_CXX='`$ECHO "$module_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-module_cmds_F77='`$ECHO "$module_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ module_expsym_cmds_CXX='`$ECHO "$module_expsym_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-module_expsym_cmds_F77='`$ECHO "$module_expsym_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ with_gnu_ld_CXX='`$ECHO "$with_gnu_ld_CXX" | $SED "$delay_single_quote_subst"`'
+-with_gnu_ld_F77='`$ECHO "$with_gnu_ld_F77" | $SED "$delay_single_quote_subst"`'
+ allow_undefined_flag_CXX='`$ECHO "$allow_undefined_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-allow_undefined_flag_F77='`$ECHO "$allow_undefined_flag_F77" | $SED "$delay_single_quote_subst"`'
+ no_undefined_flag_CXX='`$ECHO "$no_undefined_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-no_undefined_flag_F77='`$ECHO "$no_undefined_flag_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_flag_spec_CXX='`$ECHO "$hardcode_libdir_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_flag_spec_F77='`$ECHO "$hardcode_libdir_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_flag_spec_ld_CXX='`$ECHO "$hardcode_libdir_flag_spec_ld_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_flag_spec_ld_F77='`$ECHO "$hardcode_libdir_flag_spec_ld_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_separator_CXX='`$ECHO "$hardcode_libdir_separator_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_separator_F77='`$ECHO "$hardcode_libdir_separator_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_direct_CXX='`$ECHO "$hardcode_direct_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_direct_F77='`$ECHO "$hardcode_direct_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_direct_absolute_CXX='`$ECHO "$hardcode_direct_absolute_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_direct_absolute_F77='`$ECHO "$hardcode_direct_absolute_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_minus_L_CXX='`$ECHO "$hardcode_minus_L_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_minus_L_F77='`$ECHO "$hardcode_minus_L_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_shlibpath_var_CXX='`$ECHO "$hardcode_shlibpath_var_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_shlibpath_var_F77='`$ECHO "$hardcode_shlibpath_var_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_automatic_CXX='`$ECHO "$hardcode_automatic_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_automatic_F77='`$ECHO "$hardcode_automatic_F77" | $SED "$delay_single_quote_subst"`'
+ inherit_rpath_CXX='`$ECHO "$inherit_rpath_CXX" | $SED "$delay_single_quote_subst"`'
+-inherit_rpath_F77='`$ECHO "$inherit_rpath_F77" | $SED "$delay_single_quote_subst"`'
+ link_all_deplibs_CXX='`$ECHO "$link_all_deplibs_CXX" | $SED "$delay_single_quote_subst"`'
+-link_all_deplibs_F77='`$ECHO "$link_all_deplibs_F77" | $SED "$delay_single_quote_subst"`'
+ always_export_symbols_CXX='`$ECHO "$always_export_symbols_CXX" | $SED "$delay_single_quote_subst"`'
+-always_export_symbols_F77='`$ECHO "$always_export_symbols_F77" | $SED "$delay_single_quote_subst"`'
+ export_symbols_cmds_CXX='`$ECHO "$export_symbols_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-export_symbols_cmds_F77='`$ECHO "$export_symbols_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ exclude_expsyms_CXX='`$ECHO "$exclude_expsyms_CXX" | $SED "$delay_single_quote_subst"`'
+-exclude_expsyms_F77='`$ECHO "$exclude_expsyms_F77" | $SED "$delay_single_quote_subst"`'
+ include_expsyms_CXX='`$ECHO "$include_expsyms_CXX" | $SED "$delay_single_quote_subst"`'
+-include_expsyms_F77='`$ECHO "$include_expsyms_F77" | $SED "$delay_single_quote_subst"`'
+ prelink_cmds_CXX='`$ECHO "$prelink_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-prelink_cmds_F77='`$ECHO "$prelink_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ postlink_cmds_CXX='`$ECHO "$postlink_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-postlink_cmds_F77='`$ECHO "$postlink_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ file_list_spec_CXX='`$ECHO "$file_list_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-file_list_spec_F77='`$ECHO "$file_list_spec_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_action_CXX='`$ECHO "$hardcode_action_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_action_F77='`$ECHO "$hardcode_action_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_dirs_CXX='`$ECHO "$compiler_lib_search_dirs_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_lib_search_dirs_F77='`$ECHO "$compiler_lib_search_dirs_F77" | $SED "$delay_single_quote_subst"`'
+ predep_objects_CXX='`$ECHO "$predep_objects_CXX" | $SED "$delay_single_quote_subst"`'
+-predep_objects_F77='`$ECHO "$predep_objects_F77" | $SED "$delay_single_quote_subst"`'
+ postdep_objects_CXX='`$ECHO "$postdep_objects_CXX" | $SED "$delay_single_quote_subst"`'
+-postdep_objects_F77='`$ECHO "$postdep_objects_F77" | $SED "$delay_single_quote_subst"`'
+ predeps_CXX='`$ECHO "$predeps_CXX" | $SED "$delay_single_quote_subst"`'
+-predeps_F77='`$ECHO "$predeps_F77" | $SED "$delay_single_quote_subst"`'
+ postdeps_CXX='`$ECHO "$postdeps_CXX" | $SED "$delay_single_quote_subst"`'
+-postdeps_F77='`$ECHO "$postdeps_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_path_CXX='`$ECHO "$compiler_lib_search_path_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_lib_search_path_F77='`$ECHO "$compiler_lib_search_path_F77" | $SED "$delay_single_quote_subst"`'
+ 
+ LTCC='$LTCC'
+ LTCFLAGS='$LTCFLAGS'
+@@ -32767,57 +29811,31 @@
+ postdeps \
+ compiler_lib_search_path \
+ LD_CXX \
+-LD_F77 \
+ reload_flag_CXX \
+-reload_flag_F77 \
+ compiler_CXX \
+-compiler_F77 \
+ lt_prog_compiler_no_builtin_flag_CXX \
+-lt_prog_compiler_no_builtin_flag_F77 \
+ lt_prog_compiler_pic_CXX \
+-lt_prog_compiler_pic_F77 \
+ lt_prog_compiler_wl_CXX \
+-lt_prog_compiler_wl_F77 \
+ lt_prog_compiler_static_CXX \
+-lt_prog_compiler_static_F77 \
+ lt_cv_prog_compiler_c_o_CXX \
+-lt_cv_prog_compiler_c_o_F77 \
+ export_dynamic_flag_spec_CXX \
+-export_dynamic_flag_spec_F77 \
+ whole_archive_flag_spec_CXX \
+-whole_archive_flag_spec_F77 \
+ compiler_needs_object_CXX \
+-compiler_needs_object_F77 \
+ with_gnu_ld_CXX \
+-with_gnu_ld_F77 \
+ allow_undefined_flag_CXX \
+-allow_undefined_flag_F77 \
+ no_undefined_flag_CXX \
+-no_undefined_flag_F77 \
+ hardcode_libdir_flag_spec_CXX \
+-hardcode_libdir_flag_spec_F77 \
+ hardcode_libdir_flag_spec_ld_CXX \
+-hardcode_libdir_flag_spec_ld_F77 \
+ hardcode_libdir_separator_CXX \
+-hardcode_libdir_separator_F77 \
+ exclude_expsyms_CXX \
+-exclude_expsyms_F77 \
+ include_expsyms_CXX \
+-include_expsyms_F77 \
+ file_list_spec_CXX \
+-file_list_spec_F77 \
+ compiler_lib_search_dirs_CXX \
+-compiler_lib_search_dirs_F77 \
+ predep_objects_CXX \
+-predep_objects_F77 \
+ postdep_objects_CXX \
+-postdep_objects_F77 \
+ predeps_CXX \
+-predeps_F77 \
+ postdeps_CXX \
+-postdeps_F77 \
+-compiler_lib_search_path_CXX \
+-compiler_lib_search_path_F77; do
++compiler_lib_search_path_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+       eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\""
+@@ -32849,27 +29867,16 @@
+ sys_lib_search_path_spec \
+ sys_lib_dlsearch_path_spec \
+ reload_cmds_CXX \
+-reload_cmds_F77 \
+ old_archive_cmds_CXX \
+-old_archive_cmds_F77 \
+ old_archive_from_new_cmds_CXX \
+-old_archive_from_new_cmds_F77 \
+ old_archive_from_expsyms_cmds_CXX \
+-old_archive_from_expsyms_cmds_F77 \
+ archive_cmds_CXX \
+-archive_cmds_F77 \
+ archive_expsym_cmds_CXX \
+-archive_expsym_cmds_F77 \
+ module_cmds_CXX \
+-module_cmds_F77 \
+ module_expsym_cmds_CXX \
+-module_expsym_cmds_F77 \
+ export_symbols_cmds_CXX \
+-export_symbols_cmds_F77 \
+ prelink_cmds_CXX \
+-prelink_cmds_F77 \
+-postlink_cmds_CXX \
+-postlink_cmds_F77; do
++postlink_cmds_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+       eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\""
+@@ -32899,8 +29906,6 @@
+ 
+ 
+ 
+-
+-
+ ac_aux_dir='$ac_aux_dir'
+ 
+ 
+@@ -33617,7 +30622,7 @@
+ 
+ 
+ # The names of the tagged configurations supported by this script.
+-available_tags="CXX F77 "
++available_tags="CXX "
+ 
+ # ### BEGIN LIBTOOL CONFIG
+ 
+@@ -34371,163 +31376,6 @@
+ # ### END LIBTOOL TAG CONFIG: CXX
+ _LT_EOF
+ 
+-
+-    cat <<_LT_EOF >> "$ofile"
+-
+-# ### BEGIN LIBTOOL TAG CONFIG: F77
+-
+-# The linker used to build libraries.
+-LD=$lt_LD_F77
+-
+-# How to create reloadable object files.
+-reload_flag=$lt_reload_flag_F77
+-reload_cmds=$lt_reload_cmds_F77
+-
+-# Commands used to build an old-style archive.
+-old_archive_cmds=$lt_old_archive_cmds_F77
+-
+-# A language specific compiler.
+-CC=$lt_compiler_F77
+-
+-# Is the compiler the GNU compiler?
+-with_gcc=$GCC_F77
+-
+-# Compiler flag to turn off builtin functions.
+-no_builtin_flag=$lt_lt_prog_compiler_no_builtin_flag_F77
+-
+-# Additional compiler flags for building library objects.
+-pic_flag=$lt_lt_prog_compiler_pic_F77
+-
+-# How to pass a linker flag through the compiler.
+-wl=$lt_lt_prog_compiler_wl_F77
+-
+-# Compiler flag to prevent dynamic linking.
+-link_static_flag=$lt_lt_prog_compiler_static_F77
+-
+-# Does compiler simultaneously support -c and -o options?
+-compiler_c_o=$lt_lt_cv_prog_compiler_c_o_F77
+-
+-# Whether or not to add -lc for building shared libraries.
+-build_libtool_need_lc=$archive_cmds_need_lc_F77
+-
+-# Whether or not to disallow shared libs when runtime libs are static.
+-allow_libtool_libs_with_static_runtimes=$enable_shared_with_static_runtimes_F77
+-
+-# Compiler flag to allow reflexive dlopens.
+-export_dynamic_flag_spec=$lt_export_dynamic_flag_spec_F77
+-
+-# Compiler flag to generate shared objects directly from archives.
+-whole_archive_flag_spec=$lt_whole_archive_flag_spec_F77
+-
+-# Whether the compiler copes with passing no objects directly.
+-compiler_needs_object=$lt_compiler_needs_object_F77
+-
+-# Create an old-style archive from a shared archive.
+-old_archive_from_new_cmds=$lt_old_archive_from_new_cmds_F77
+-
+-# Create a temporary old-style archive to link instead of a shared archive.
+-old_archive_from_expsyms_cmds=$lt_old_archive_from_expsyms_cmds_F77
+-
+-# Commands used to build a shared archive.
+-archive_cmds=$lt_archive_cmds_F77
+-archive_expsym_cmds=$lt_archive_expsym_cmds_F77
+-
+-# Commands used to build a loadable module if different from building
+-# a shared archive.
+-module_cmds=$lt_module_cmds_F77
+-module_expsym_cmds=$lt_module_expsym_cmds_F77
+-
+-# Whether we are building with GNU ld or not.
+-with_gnu_ld=$lt_with_gnu_ld_F77
+-
+-# Flag that allows shared libraries with undefined symbols to be built.
+-allow_undefined_flag=$lt_allow_undefined_flag_F77
+-
+-# Flag that enforces no undefined symbols.
+-no_undefined_flag=$lt_no_undefined_flag_F77
+-
+-# Flag to hardcode \$libdir into a binary during linking.
+-# This must work even if \$libdir does not exist
+-hardcode_libdir_flag_spec=$lt_hardcode_libdir_flag_spec_F77
+-
+-# If ld is used when linking, flag to hardcode \$libdir into a binary
+-# during linking.  This must work even if \$libdir does not exist.
+-hardcode_libdir_flag_spec_ld=$lt_hardcode_libdir_flag_spec_ld_F77
+-
+-# Whether we need a single "-rpath" flag with a separated argument.
+-hardcode_libdir_separator=$lt_hardcode_libdir_separator_F77
+-
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
+-# DIR into the resulting binary.
+-hardcode_direct=$hardcode_direct_F77
+-
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
+-# DIR into the resulting binary and the resulting library dependency is
+-# "absolute",i.e impossible to change by setting \${shlibpath_var} if the
+-# library is relocated.
+-hardcode_direct_absolute=$hardcode_direct_absolute_F77
+-
+-# Set to "yes" if using the -LDIR flag during linking hardcodes DIR
+-# into the resulting binary.
+-hardcode_minus_L=$hardcode_minus_L_F77
+-
+-# Set to "yes" if using SHLIBPATH_VAR=DIR during linking hardcodes DIR
+-# into the resulting binary.
+-hardcode_shlibpath_var=$hardcode_shlibpath_var_F77
+-
+-# Set to "yes" if building a shared library automatically hardcodes DIR
+-# into the library and all subsequent libraries and executables linked
+-# against it.
+-hardcode_automatic=$hardcode_automatic_F77
+-
+-# Set to yes if linker adds runtime paths of dependent libraries
+-# to runtime path list.
+-inherit_rpath=$inherit_rpath_F77
+-
+-# Whether libtool must link a program against all its dependency libraries.
+-link_all_deplibs=$link_all_deplibs_F77
+-
+-# Set to "yes" if exported symbols are required.
+-always_export_symbols=$always_export_symbols_F77
+-
+-# The commands to list exported symbols.
+-export_symbols_cmds=$lt_export_symbols_cmds_F77
+-
+-# Symbols that should not be listed in the preloaded symbols.
+-exclude_expsyms=$lt_exclude_expsyms_F77
+-
+-# Symbols that must always be exported.
+-include_expsyms=$lt_include_expsyms_F77
+-
+-# Commands necessary for linking programs (against libraries) with templates.
+-prelink_cmds=$lt_prelink_cmds_F77
+-
+-# Commands necessary for finishing linking programs.
+-postlink_cmds=$lt_postlink_cmds_F77
+-
+-# Specify filename containing input files.
+-file_list_spec=$lt_file_list_spec_F77
+-
+-# How to hardcode a shared library path into an executable.
+-hardcode_action=$hardcode_action_F77
+-
+-# The directories searched by this compiler when creating a shared library.
+-compiler_lib_search_dirs=$lt_compiler_lib_search_dirs_F77
+-
+-# Dependencies to place before and after the objects being linked to
+-# create a shared library.
+-predep_objects=$lt_predep_objects_F77
+-postdep_objects=$lt_postdep_objects_F77
+-predeps=$lt_predeps_F77
+-postdeps=$lt_postdeps_F77
+-
+-# The library search path used internally by the compiler when linking
+-# a shared library.
+-compiler_lib_search_path=$lt_compiler_lib_search_path_F77
+-
+-# ### END LIBTOOL TAG CONFIG: F77
+-_LT_EOF
+-
+  ;;
+ 
+   esac
+@@ -35610,103 +32458,54 @@
+ postdeps='`$ECHO "$postdeps" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_path='`$ECHO "$compiler_lib_search_path" | $SED "$delay_single_quote_subst"`'
+ LD_CXX='`$ECHO "$LD_CXX" | $SED "$delay_single_quote_subst"`'
+-LD_F77='`$ECHO "$LD_F77" | $SED "$delay_single_quote_subst"`'
+ reload_flag_CXX='`$ECHO "$reload_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-reload_flag_F77='`$ECHO "$reload_flag_F77" | $SED "$delay_single_quote_subst"`'
+ reload_cmds_CXX='`$ECHO "$reload_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-reload_cmds_F77='`$ECHO "$reload_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_cmds_CXX='`$ECHO "$old_archive_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_cmds_F77='`$ECHO "$old_archive_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_CXX='`$ECHO "$compiler_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_F77='`$ECHO "$compiler_F77" | $SED "$delay_single_quote_subst"`'
+ GCC_CXX='`$ECHO "$GCC_CXX" | $SED "$delay_single_quote_subst"`'
+-GCC_F77='`$ECHO "$GCC_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_no_builtin_flag_CXX='`$ECHO "$lt_prog_compiler_no_builtin_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_no_builtin_flag_F77='`$ECHO "$lt_prog_compiler_no_builtin_flag_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_pic_CXX='`$ECHO "$lt_prog_compiler_pic_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_pic_F77='`$ECHO "$lt_prog_compiler_pic_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_wl_CXX='`$ECHO "$lt_prog_compiler_wl_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_wl_F77='`$ECHO "$lt_prog_compiler_wl_F77" | $SED "$delay_single_quote_subst"`'
+ lt_prog_compiler_static_CXX='`$ECHO "$lt_prog_compiler_static_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_prog_compiler_static_F77='`$ECHO "$lt_prog_compiler_static_F77" | $SED "$delay_single_quote_subst"`'
+ lt_cv_prog_compiler_c_o_CXX='`$ECHO "$lt_cv_prog_compiler_c_o_CXX" | $SED "$delay_single_quote_subst"`'
+-lt_cv_prog_compiler_c_o_F77='`$ECHO "$lt_cv_prog_compiler_c_o_F77" | $SED "$delay_single_quote_subst"`'
+ archive_cmds_need_lc_CXX='`$ECHO "$archive_cmds_need_lc_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_cmds_need_lc_F77='`$ECHO "$archive_cmds_need_lc_F77" | $SED "$delay_single_quote_subst"`'
+ enable_shared_with_static_runtimes_CXX='`$ECHO "$enable_shared_with_static_runtimes_CXX" | $SED "$delay_single_quote_subst"`'
+-enable_shared_with_static_runtimes_F77='`$ECHO "$enable_shared_with_static_runtimes_F77" | $SED "$delay_single_quote_subst"`'
+ export_dynamic_flag_spec_CXX='`$ECHO "$export_dynamic_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-export_dynamic_flag_spec_F77='`$ECHO "$export_dynamic_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ whole_archive_flag_spec_CXX='`$ECHO "$whole_archive_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-whole_archive_flag_spec_F77='`$ECHO "$whole_archive_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_needs_object_CXX='`$ECHO "$compiler_needs_object_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_needs_object_F77='`$ECHO "$compiler_needs_object_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_from_new_cmds_CXX='`$ECHO "$old_archive_from_new_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_from_new_cmds_F77='`$ECHO "$old_archive_from_new_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ old_archive_from_expsyms_cmds_CXX='`$ECHO "$old_archive_from_expsyms_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-old_archive_from_expsyms_cmds_F77='`$ECHO "$old_archive_from_expsyms_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ archive_cmds_CXX='`$ECHO "$archive_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_cmds_F77='`$ECHO "$archive_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ archive_expsym_cmds_CXX='`$ECHO "$archive_expsym_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-archive_expsym_cmds_F77='`$ECHO "$archive_expsym_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ module_cmds_CXX='`$ECHO "$module_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-module_cmds_F77='`$ECHO "$module_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ module_expsym_cmds_CXX='`$ECHO "$module_expsym_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-module_expsym_cmds_F77='`$ECHO "$module_expsym_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ with_gnu_ld_CXX='`$ECHO "$with_gnu_ld_CXX" | $SED "$delay_single_quote_subst"`'
+-with_gnu_ld_F77='`$ECHO "$with_gnu_ld_F77" | $SED "$delay_single_quote_subst"`'
+ allow_undefined_flag_CXX='`$ECHO "$allow_undefined_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-allow_undefined_flag_F77='`$ECHO "$allow_undefined_flag_F77" | $SED "$delay_single_quote_subst"`'
+ no_undefined_flag_CXX='`$ECHO "$no_undefined_flag_CXX" | $SED "$delay_single_quote_subst"`'
+-no_undefined_flag_F77='`$ECHO "$no_undefined_flag_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_flag_spec_CXX='`$ECHO "$hardcode_libdir_flag_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_flag_spec_F77='`$ECHO "$hardcode_libdir_flag_spec_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_flag_spec_ld_CXX='`$ECHO "$hardcode_libdir_flag_spec_ld_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_flag_spec_ld_F77='`$ECHO "$hardcode_libdir_flag_spec_ld_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_libdir_separator_CXX='`$ECHO "$hardcode_libdir_separator_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_libdir_separator_F77='`$ECHO "$hardcode_libdir_separator_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_direct_CXX='`$ECHO "$hardcode_direct_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_direct_F77='`$ECHO "$hardcode_direct_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_direct_absolute_CXX='`$ECHO "$hardcode_direct_absolute_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_direct_absolute_F77='`$ECHO "$hardcode_direct_absolute_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_minus_L_CXX='`$ECHO "$hardcode_minus_L_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_minus_L_F77='`$ECHO "$hardcode_minus_L_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_shlibpath_var_CXX='`$ECHO "$hardcode_shlibpath_var_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_shlibpath_var_F77='`$ECHO "$hardcode_shlibpath_var_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_automatic_CXX='`$ECHO "$hardcode_automatic_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_automatic_F77='`$ECHO "$hardcode_automatic_F77" | $SED "$delay_single_quote_subst"`'
+ inherit_rpath_CXX='`$ECHO "$inherit_rpath_CXX" | $SED "$delay_single_quote_subst"`'
+-inherit_rpath_F77='`$ECHO "$inherit_rpath_F77" | $SED "$delay_single_quote_subst"`'
+ link_all_deplibs_CXX='`$ECHO "$link_all_deplibs_CXX" | $SED "$delay_single_quote_subst"`'
+-link_all_deplibs_F77='`$ECHO "$link_all_deplibs_F77" | $SED "$delay_single_quote_subst"`'
+ always_export_symbols_CXX='`$ECHO "$always_export_symbols_CXX" | $SED "$delay_single_quote_subst"`'
+-always_export_symbols_F77='`$ECHO "$always_export_symbols_F77" | $SED "$delay_single_quote_subst"`'
+ export_symbols_cmds_CXX='`$ECHO "$export_symbols_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-export_symbols_cmds_F77='`$ECHO "$export_symbols_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ exclude_expsyms_CXX='`$ECHO "$exclude_expsyms_CXX" | $SED "$delay_single_quote_subst"`'
+-exclude_expsyms_F77='`$ECHO "$exclude_expsyms_F77" | $SED "$delay_single_quote_subst"`'
+ include_expsyms_CXX='`$ECHO "$include_expsyms_CXX" | $SED "$delay_single_quote_subst"`'
+-include_expsyms_F77='`$ECHO "$include_expsyms_F77" | $SED "$delay_single_quote_subst"`'
+ prelink_cmds_CXX='`$ECHO "$prelink_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-prelink_cmds_F77='`$ECHO "$prelink_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ postlink_cmds_CXX='`$ECHO "$postlink_cmds_CXX" | $SED "$delay_single_quote_subst"`'
+-postlink_cmds_F77='`$ECHO "$postlink_cmds_F77" | $SED "$delay_single_quote_subst"`'
+ file_list_spec_CXX='`$ECHO "$file_list_spec_CXX" | $SED "$delay_single_quote_subst"`'
+-file_list_spec_F77='`$ECHO "$file_list_spec_F77" | $SED "$delay_single_quote_subst"`'
+ hardcode_action_CXX='`$ECHO "$hardcode_action_CXX" | $SED "$delay_single_quote_subst"`'
+-hardcode_action_F77='`$ECHO "$hardcode_action_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_dirs_CXX='`$ECHO "$compiler_lib_search_dirs_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_lib_search_dirs_F77='`$ECHO "$compiler_lib_search_dirs_F77" | $SED "$delay_single_quote_subst"`'
+ predep_objects_CXX='`$ECHO "$predep_objects_CXX" | $SED "$delay_single_quote_subst"`'
+-predep_objects_F77='`$ECHO "$predep_objects_F77" | $SED "$delay_single_quote_subst"`'
+ postdep_objects_CXX='`$ECHO "$postdep_objects_CXX" | $SED "$delay_single_quote_subst"`'
+-postdep_objects_F77='`$ECHO "$postdep_objects_F77" | $SED "$delay_single_quote_subst"`'
+ predeps_CXX='`$ECHO "$predeps_CXX" | $SED "$delay_single_quote_subst"`'
+-predeps_F77='`$ECHO "$predeps_F77" | $SED "$delay_single_quote_subst"`'
+ postdeps_CXX='`$ECHO "$postdeps_CXX" | $SED "$delay_single_quote_subst"`'
+-postdeps_F77='`$ECHO "$postdeps_F77" | $SED "$delay_single_quote_subst"`'
+ compiler_lib_search_path_CXX='`$ECHO "$compiler_lib_search_path_CXX" | $SED "$delay_single_quote_subst"`'
+-compiler_lib_search_path_F77='`$ECHO "$compiler_lib_search_path_F77" | $SED "$delay_single_quote_subst"`'
+ 
+ LTCC='$LTCC'
+ LTCFLAGS='$LTCFLAGS'
+@@ -35794,57 +32593,31 @@
+ postdeps \
+ compiler_lib_search_path \
+ LD_CXX \
+-LD_F77 \
+ reload_flag_CXX \
+-reload_flag_F77 \
+ compiler_CXX \
+-compiler_F77 \
+ lt_prog_compiler_no_builtin_flag_CXX \
+-lt_prog_compiler_no_builtin_flag_F77 \
+ lt_prog_compiler_pic_CXX \
+-lt_prog_compiler_pic_F77 \
+ lt_prog_compiler_wl_CXX \
+-lt_prog_compiler_wl_F77 \
+ lt_prog_compiler_static_CXX \
+-lt_prog_compiler_static_F77 \
+ lt_cv_prog_compiler_c_o_CXX \
+-lt_cv_prog_compiler_c_o_F77 \
+ export_dynamic_flag_spec_CXX \
+-export_dynamic_flag_spec_F77 \
+ whole_archive_flag_spec_CXX \
+-whole_archive_flag_spec_F77 \
+ compiler_needs_object_CXX \
+-compiler_needs_object_F77 \
+ with_gnu_ld_CXX \
+-with_gnu_ld_F77 \
+ allow_undefined_flag_CXX \
+-allow_undefined_flag_F77 \
+ no_undefined_flag_CXX \
+-no_undefined_flag_F77 \
+ hardcode_libdir_flag_spec_CXX \
+-hardcode_libdir_flag_spec_F77 \
+ hardcode_libdir_flag_spec_ld_CXX \
+-hardcode_libdir_flag_spec_ld_F77 \
+ hardcode_libdir_separator_CXX \
+-hardcode_libdir_separator_F77 \
+ exclude_expsyms_CXX \
+-exclude_expsyms_F77 \
+ include_expsyms_CXX \
+-include_expsyms_F77 \
+ file_list_spec_CXX \
+-file_list_spec_F77 \
+ compiler_lib_search_dirs_CXX \
+-compiler_lib_search_dirs_F77 \
+ predep_objects_CXX \
+-predep_objects_F77 \
+ postdep_objects_CXX \
+-postdep_objects_F77 \
+ predeps_CXX \
+-predeps_F77 \
+ postdeps_CXX \
+-postdeps_F77 \
+-compiler_lib_search_path_CXX \
+-compiler_lib_search_path_F77; do
++compiler_lib_search_path_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+       eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\""
+@@ -35876,27 +32649,16 @@
+ sys_lib_search_path_spec \
+ sys_lib_dlsearch_path_spec \
+ reload_cmds_CXX \
+-reload_cmds_F77 \
+ old_archive_cmds_CXX \
+-old_archive_cmds_F77 \
+ old_archive_from_new_cmds_CXX \
+-old_archive_from_new_cmds_F77 \
+ old_archive_from_expsyms_cmds_CXX \
+-old_archive_from_expsyms_cmds_F77 \
+ archive_cmds_CXX \
+-archive_cmds_F77 \
+ archive_expsym_cmds_CXX \
+-archive_expsym_cmds_F77 \
+ module_cmds_CXX \
+-module_cmds_F77 \
+ module_expsym_cmds_CXX \
+-module_expsym_cmds_F77 \
+ export_symbols_cmds_CXX \
+-export_symbols_cmds_F77 \
+ prelink_cmds_CXX \
+-prelink_cmds_F77 \
+-postlink_cmds_CXX \
+-postlink_cmds_F77; do
++postlink_cmds_CXX; do
+     case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
+     *[\\\\\\\`\\"\\\$]*)
+       eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\""
+@@ -35926,8 +32688,6 @@
+ 
+ 
+ 
+-
+-
+ ac_aux_dir='$ac_aux_dir'
+ ac_aux_dir='$ac_aux_dir'
+ 
+@@ -36646,7 +33406,7 @@
+ 
+ 
+ # The names of the tagged configurations supported by this script.
+-available_tags="CXX F77 "
++available_tags="CXX "
+ 
+ # ### BEGIN LIBTOOL CONFIG
+ 
+@@ -37400,163 +34160,6 @@
+ # ### END LIBTOOL TAG CONFIG: CXX
+ _LT_EOF
+ 
+-
+-    cat <<_LT_EOF >> "$ofile"
+-
+-# ### BEGIN LIBTOOL TAG CONFIG: F77
+-
+-# The linker used to build libraries.
+-LD=$lt_LD_F77
+-
+-# How to create reloadable object files.
+-reload_flag=$lt_reload_flag_F77
+-reload_cmds=$lt_reload_cmds_F77
+-
+-# Commands used to build an old-style archive.
+-old_archive_cmds=$lt_old_archive_cmds_F77
+-
+-# A language specific compiler.
+-CC=$lt_compiler_F77
+-
+-# Is the compiler the GNU compiler?
+-with_gcc=$GCC_F77
+-
+-# Compiler flag to turn off builtin functions.
+-no_builtin_flag=$lt_lt_prog_compiler_no_builtin_flag_F77
+-
+-# Additional compiler flags for building library objects.
+-pic_flag=$lt_lt_prog_compiler_pic_F77
+-
+-# How to pass a linker flag through the compiler.
+-wl=$lt_lt_prog_compiler_wl_F77
+-
+-# Compiler flag to prevent dynamic linking.
+-link_static_flag=$lt_lt_prog_compiler_static_F77
+-
+-# Does compiler simultaneously support -c and -o options?
+-compiler_c_o=$lt_lt_cv_prog_compiler_c_o_F77
+-
+-# Whether or not to add -lc for building shared libraries.
+-build_libtool_need_lc=$archive_cmds_need_lc_F77
+-
+-# Whether or not to disallow shared libs when runtime libs are static.
+-allow_libtool_libs_with_static_runtimes=$enable_shared_with_static_runtimes_F77
+-
+-# Compiler flag to allow reflexive dlopens.
+-export_dynamic_flag_spec=$lt_export_dynamic_flag_spec_F77
+-
+-# Compiler flag to generate shared objects directly from archives.
+-whole_archive_flag_spec=$lt_whole_archive_flag_spec_F77
+-
+-# Whether the compiler copes with passing no objects directly.
+-compiler_needs_object=$lt_compiler_needs_object_F77
+-
+-# Create an old-style archive from a shared archive.
+-old_archive_from_new_cmds=$lt_old_archive_from_new_cmds_F77
+-
+-# Create a temporary old-style archive to link instead of a shared archive.
+-old_archive_from_expsyms_cmds=$lt_old_archive_from_expsyms_cmds_F77
+-
+-# Commands used to build a shared archive.
+-archive_cmds=$lt_archive_cmds_F77
+-archive_expsym_cmds=$lt_archive_expsym_cmds_F77
+-
+-# Commands used to build a loadable module if different from building
+-# a shared archive.
+-module_cmds=$lt_module_cmds_F77
+-module_expsym_cmds=$lt_module_expsym_cmds_F77
+-
+-# Whether we are building with GNU ld or not.
+-with_gnu_ld=$lt_with_gnu_ld_F77
+-
+-# Flag that allows shared libraries with undefined symbols to be built.
+-allow_undefined_flag=$lt_allow_undefined_flag_F77
+-
+-# Flag that enforces no undefined symbols.
+-no_undefined_flag=$lt_no_undefined_flag_F77
+-
+-# Flag to hardcode \$libdir into a binary during linking.
+-# This must work even if \$libdir does not exist
+-hardcode_libdir_flag_spec=$lt_hardcode_libdir_flag_spec_F77
+-
+-# If ld is used when linking, flag to hardcode \$libdir into a binary
+-# during linking.  This must work even if \$libdir does not exist.
+-hardcode_libdir_flag_spec_ld=$lt_hardcode_libdir_flag_spec_ld_F77
+-
+-# Whether we need a single "-rpath" flag with a separated argument.
+-hardcode_libdir_separator=$lt_hardcode_libdir_separator_F77
+-
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
+-# DIR into the resulting binary.
+-hardcode_direct=$hardcode_direct_F77
+-
+-# Set to "yes" if using DIR/libNAME\${shared_ext} during linking hardcodes
+-# DIR into the resulting binary and the resulting library dependency is
+-# "absolute",i.e impossible to change by setting \${shlibpath_var} if the
+-# library is relocated.
+-hardcode_direct_absolute=$hardcode_direct_absolute_F77
+-
+-# Set to "yes" if using the -LDIR flag during linking hardcodes DIR
+-# into the resulting binary.
+-hardcode_minus_L=$hardcode_minus_L_F77
+-
+-# Set to "yes" if using SHLIBPATH_VAR=DIR during linking hardcodes DIR
+-# into the resulting binary.
+-hardcode_shlibpath_var=$hardcode_shlibpath_var_F77
+-
+-# Set to "yes" if building a shared library automatically hardcodes DIR
+-# into the library and all subsequent libraries and executables linked
+-# against it.
+-hardcode_automatic=$hardcode_automatic_F77
+-
+-# Set to yes if linker adds runtime paths of dependent libraries
+-# to runtime path list.
+-inherit_rpath=$inherit_rpath_F77
+-
+-# Whether libtool must link a program against all its dependency libraries.
+-link_all_deplibs=$link_all_deplibs_F77
+-
+-# Set to "yes" if exported symbols are required.
+-always_export_symbols=$always_export_symbols_F77
+-
+-# The commands to list exported symbols.
+-export_symbols_cmds=$lt_export_symbols_cmds_F77
+-
+-# Symbols that should not be listed in the preloaded symbols.
+-exclude_expsyms=$lt_exclude_expsyms_F77
+-
+-# Symbols that must always be exported.
+-include_expsyms=$lt_include_expsyms_F77
+-
+-# Commands necessary for linking programs (against libraries) with templates.
+-prelink_cmds=$lt_prelink_cmds_F77
+-
+-# Commands necessary for finishing linking programs.
+-postlink_cmds=$lt_postlink_cmds_F77
+-
+-# Specify filename containing input files.
+-file_list_spec=$lt_file_list_spec_F77
+-
+-# How to hardcode a shared library path into an executable.
+-hardcode_action=$hardcode_action_F77
+-
+-# The directories searched by this compiler when creating a shared library.
+-compiler_lib_search_dirs=$lt_compiler_lib_search_dirs_F77
+-
+-# Dependencies to place before and after the objects being linked to
+-# create a shared library.
+-predep_objects=$lt_predep_objects_F77
+-postdep_objects=$lt_postdep_objects_F77
+-predeps=$lt_predeps_F77
+-postdeps=$lt_postdeps_F77
+-
+-# The library search path used internally by the compiler when linking
+-# a shared library.
+-compiler_lib_search_path=$lt_compiler_lib_search_path_F77
+-
+-# ### END LIBTOOL TAG CONFIG: F77
+-_LT_EOF
+-
+  ;;
+ 
+   esac


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12970">trac #12970</a>.

Diff between the 2.4.0.p4 and 2.4.0.p5 spkgs. For reference / review only.

Reported by: kini

Component: packages

CC: was,, jdemeyer,, leif

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12954">trac #12954</a>

Work issues: 

Reviewers: Volker Braun, William Stein

Merged in: sage-5.0.1.rc0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12970/configure.patch">configure.patch: Patch for configure.in and related files inside the spkg, for review only</a> by jdemeyer at 20120528T05:42:24</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12970/mpir-2.4.0.p5.diff">mpir-2.4.0.p5.diff: Diff between the 2.4.0.p4 and 2.4.0.p5 spkgs. For reference / review only.</a> by jdemeyer at 20120528T05:56:50</li></ol>
