### PR TITLE
Cannot import rpy2.rinterface.rinterface on Cygwin

### DIFF
--- a/src/bin/sage-env
+++ b/src/bin/sage-env
@@ -530,7 +530,7 @@ if [ "$TOUCH" = "" ]; then
 fi
 
 if [ "$UNAME" = "CYGWIN" ]; then
-    PATH="$PATH:$SAGE_LOCAL/lib" && export PATH
+    PATH="$PATH:$SAGE_LOCAL/lib:$SAGE_LOCAL/lib/R/lib" && export PATH
 fi
 
 # See trac 7186 -- this is needed if ecl is moved


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13350">trac #13350</a>.

Reported by: jpflori

Component: cygwin

CC: kcrisman

Report Upstream: N/A

Authors: Jean-Pierre Flori

Dependencies: 

Work issues: 

Reviewers: Karl-Dieter Crisman

Merged in: sage-5.7.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13350/trac_13350.patch">trac_13350.patch: </a> by jpflori at 20120808T21:54:09</li></ol>
