### PR TITLE
[ARM] Maxima has a strange numerical precision issue

### DIFF
--- a/build/pkgs/ecl/SPKG.txt
+++ b/build/pkgs/ecl/SPKG.txt
@@ -65,6 +65,10 @@ Website: http://ecls.sourceforge.net/
 
 == Changelog ==
 
+=== ecl-11.1.2.cvs20111120.p2 (Julien Puydt, 27 May 2012) ===
+ * #12586: Added a patch from Juan Jose Garcia-Ripoll (upstream) fixing
+   the problem (scale_exponent.patch).
+
 === ecl-11.1.2.cvs20111120.p1 (Simon King, 10 December 2011) ===
  * #12131: Use --libdir, to make the package work on openSUSE.
 

--- a/build/pkgs/ecl/patches/scale_exponent.patch
+++ b/build/pkgs/ecl/patches/scale_exponent.patch
@@ -1,0 +1,57 @@
+diff --git a/src/lsp/format.lsp b/src/lsp/format.lsp
+index 565318d..7be931f 100644
+--- a/src/lsp/format.lsp
++++ b/src/lsp/format.lsp
+@@ -168,11 +168,47 @@
+ ;;; scaling is always done with long float arithmetic, which helps printing of
+ ;;; lesser precisions as well as avoiding generic arithmetic.
+ ;;;
+-;;;    When computing our initial scale factor using EXPT, we pull out part of
+-;;; the computation to avoid over/under flow.  When denormalized, we must pull
+-;;; out a large factor, since there is more negative exponent range than
+-;;; positive range.
+-;;;
++(defun scale-exponent (original-x)
++  (let* ((x (coerce original-x 'long-float))
++	 (delta 0))
++    (declare (long-float x)
++	     (fixnum delta)
++	     (optimize (debug 0) (safety 0)))
++    (multiple-value-bind (sig exponent)
++	(decode-float x)
++      (declare (ignore sig)
++	       (fixnum exponent)
++	       (long-float sig))
++      (when (zerop x)
++	(return-from scale-exponent (values (float 0.0l0 original-x) 1)))
++      ;; When computing our initial scale factor using EXPT, we pull out part of
++      ;; the computation to avoid over/under flow.  When denormalized, we must pull
++      ;; out a large factor, since there is more negative exponent range than
++      ;; positive range.
++      (when (and (minusp exponent)
++		 (< least-negative-normalized-long-float x
++		    least-positive-normalized-long-float))
++	#+long-float
++	(setf x (* x 1.0l18) delta -18)
++	#-long-float
++	(setf x (* x 1.0l16) delta -16))
++      ;; We find the appropriate factor that keeps the output within (0.1,1]
++      ;; Note that we have to compute the exponential _every_ _time_ in the loop
++      ;; because multiplying just by 10.0l0 every time would lead to a greater
++      ;; loss of precission.
++      (loop with ex of-type fixnum
++	   = (round (* exponent #.(log 2l0 10)))
++	 for y of-type long-float
++	   = (if (minusp ex)
++		 (* x (the long-float (expt 10.0l0 (- ex))))
++		 (/ x (the long-float (expt 10.0l0 ex))))
++	 do (cond ((<= y 0.1l0)
++		   (decf ex))
++		  ((> y 1.0l0)
++		   (incf ex))
++		  (t
++		   (return (values y (the fixnum (+ delta ex))))))))))
++#+(or)
+ (defun scale-exponent (original-x)
+   (let* ((x (coerce original-x 'long-float)))
+     (multiple-value-bind (sig exponent)


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12586">trac #12586</a>.

Reported by: Snark

Component: porting

CC: 

Report Upstream: N/A

Authors: Julien Puydt

Dependencies: 

Work issues: 

Reviewers: Dmitrii Pasechnik

Merged in: sage-5.5.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12586/ticket_12586_fix_doctest-v2.patch">ticket_12586_fix_doctest-v2.patch: </a> by jdemeyer at 20121030T16:06:57</li></ol>
