### PR TITLE
LinBox (1.1.6) fails to build with GCC 4.7.0, and lacks an `spkg-check`

### DIFF
--- a/build/pkgs/linbox/SPKG.txt
+++ b/build/pkgs/linbox/SPKG.txt
@@ -37,6 +37,12 @@ LGPL V2 or later
 
 == Changelog ==
 
+=== linbox-1.1.6.p10 (Jeroen Demeyer, 25 May 2012) ===
+ * #12762 review: Remove the touching of linbox.pyx, since
+   Cython knows the dependency of linbox.pyx on linbox-sage.h
+ * Only add the -fpermissive workaround on GCC-4.7.x, not other
+   compilers.
+
 === linbox-1.1.6.p9 (Leif Leonhardy, April 7th 2012) ===
  * #12762: Temporarily add `-fpermissive` to `CXXFLAGS` if we're compiling
    with `g++` 4.7.x, since the LinBox sources currently don't conform to

--- a/build/pkgs/linbox/spkg-install
+++ b/build/pkgs/linbox/spkg-install
@@ -29,8 +29,8 @@ done
 CFLAGS="-g $CFLAGS -fPIC"
 CXXFLAGS="-g $CXXFLAGS -fPIC"
 
-case "`$CXX -dumpversion 2>/dev/null`" in
-    4.7.*)
+case "`testcxx.sh $CXX`-`$CXX -dumpversion 2>/dev/null`" in
+    GCC-4.7.*)
         echo "Adding '-fpermissive' to CXXFLAGS to make LinBox build with GCC 4.7.x."
         echo "This is a temporary fix; LinBox currently doesn't conform to the C++11 standard."
         CXXFLAGS="-fpermissive $CXXFLAGS" # The user might still override that.
@@ -120,20 +120,3 @@ if [ $? -ne 0 ]; then
     echo >&2 "Error installing LinBox."
     exit 1
 fi
-
-echo "Installation of LinBox completed."
-
-# Touch sources of Python extension modules using LinBox such that they get
-# rebuilt the next time the Sage library gets (re)built (e.g. by './sage -b'):
-# (In principle, such modules should depend on a header file with a fresh
-# timestamp each time LinBox gets reinstalled.  Then Cython would automatically
-# rebuild them.)
-echo "Touching extension modules linked against LinBox to force their rebuild..."
-prefix="$SAGE_ROOT/devel/sage"
-modules="sage/libs/linbox/linbox.pyx"
-for pyx in $modules; do
-    if [ -f "$prefix/$pyx" ]; then
-        echo "    $pyx"
-        touch "$prefix/$pyx"
-    fi
-done


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12762">trac #12762</a>.

Diff between leif's p9 (a rebased p8) and my p10 spkgs. For reference / review only.

Reported by: leif

Component: packages

CC: cpernet,, was,, mariah

Report Upstream: N/A

Authors: Leif Leonhardy

Dependencies: 

Work issues: 

Reviewers: Jeroen Demeyer, Karl-Dieter Crisman

Merged in: sage-5.0.1.rc1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12762/linbox-1.1.6.p7-p8.diff">linbox-1.1.6.p7-p8.diff: Diff between the previous spkg in Sage and my new p8 spkg.  For reference / review only.</a> by leif at 20120407T20:09:34</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12762/linbox-1.1.6.p10.diff">linbox-1.1.6.p10.diff: Diff between leif's p9 (a rebased p8) and my p10 spkgs. For reference / review only.</a> by jdemeyer at 20120526T00:28:19</li></ol>
