### PR TITLE
update M4RI to newest upstream release

### DIFF
--- a/build/pkgs/libm4ri/SPKG.txt
+++ b/build/pkgs/libm4ri/SPKG.txt
@@ -31,7 +31,7 @@ GF(2).  (See also m4ri/README for a brief overview.)
 
 == Releases/Changelog ==
 
-=== libm4ri-20120415 (Martin Albrecht, 13 April 2012) ===
+=== libm4ri-20120422 (Martin Albrecht, 22 May 2012) ===
  * #12840: new upstream release
  * remove old headers before installing new ones
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12840">trac #12840</a>.

Reported by: malb

Component: packages

CC: 

Report Upstream: N/A

Authors: Martin Albrecht, John Palmieri

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/o be merged with #12841">trac #o be merged with #12841</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/13109">trac #13109</a>

Work issues: 

Reviewers: Simon King, Volker Braun

Merged in: sage-5.3.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12840/trac_12840_m4ri_new_version.patch">trac_12840_m4ri_new_version.patch: </a> by malb at 20120414T10:47:28</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12840/trac_12840_m4ri_png.patch">trac_12840_m4ri_png.patch: </a> by malb at 20120508T20:34:21</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12840/trac_12840-rebased-on-13109.patch">trac_12840-rebased-on-13109.patch: </a> by jhpalmieri at 20120630T17:57:13</li></ol>
