### PR TITLE
Failures in gp pexpect interface with specific length of $DOT_SAGE using a "screen" terminal

### DIFF
--- a/build/pkgs/pexpect/SPKG.txt
+++ b/build/pkgs/pexpect/SPKG.txt
@@ -7,6 +7,8 @@ controlling them; and responding to expected patterns in their output.
 
 == License ==
 
+Python Software Foundation License
+
 == SPKG Maintainers ==
 
  * William Stein
@@ -15,18 +17,33 @@ controlling them; and responding to expected patterns in their output.
 
 == Dependencies ==
 
+ * GNU patch
  * Python
 
 == Special Update/Build Instructions ==
 
- * This is a svn checkout. Note that on MacIntel OSX one has to remove a number of files due to PIC issues. The problem will be fixed upstream.
- * pexpect-2.1 is shockingly slow for SAGE (especially in the notebook) and I can't figure out why.  So we're sticking with p
-expect-2.0 for now (which works fine for us).
- * put a try/except around __del__, to get rid of lots of pointless warning messages.
+ * pexpect-2.1 is shockingly slow for Sage (especially in the notebook)
+   and I can't figure out why.  So we're sticking with pexpect-2.0 for
+   now (which works fine for us).
+
+Patches:
+ * del.patch: put a try/except inside __del__, to get rid of lots of
+   pointless warning messages
+ * pexpect.py-isdir_bug_fix.patch: fixed bug in pexpect.py where it
+   tried to run directories
+ * env.patch: add env parameter to spawn.__init__() to run a command
+   with custom environment variables (as in pexpect-2.3).
 
 == Changelog ==
 
-=== pexpect-2.0.p3 (Michael Abshoff, Janury 8th, 2009) ===
+=== pexpect-2.0.p5 (Jeroen Demeyer, 13 January 2012) ===
+ * Trac #12221: add env.patch to add env parameter to spawn.__init__()
+ * Restore upstream sources, use patch for patching
+
+=== pexpect-2.0.p4 ===
+ * undocumented
+
+=== pexpect-2.0.p3 (Michael Abshoff, January 28th, 2009) ===
  * further clean up SPKG.txt
  * add .hgignore
 

--- a/build/pkgs/pexpect/patches/del.patch
+++ b/build/pkgs/pexpect/patches/del.patch
@@ -1,0 +1,15 @@
+diff -ru src/pexpect.py src.del/pexpect.py
+--- src/pexpect.py	2005-11-17 15:36:09.000000000 +0100
++++ src.del/pexpect.py	2012-01-13 10:24:01.000000000 +0100
+@@ -341,7 +341,10 @@
+         """
+         if self.closed:
+             return
+-        self.close()
++        try:
++            self.close()
++        except:
++            pass
+ 
+     def __str__(self):
+         """This returns the current state of the pexpect object as a string.

--- a/build/pkgs/pexpect/patches/env.patch
+++ b/build/pkgs/pexpect/patches/env.patch
@@ -1,0 +1,32 @@
+diff -ru src.p4/pexpect.py src.new/pexpect.py
+--- src.p4/pexpect.py	2009-01-23 11:01:57.000000000 +0100
++++ src.new/pexpect.py	2012-01-12 13:38:06.000000000 +0100
+@@ -209,7 +209,7 @@
+     Use this class to start and control child applications.
+     """
+ 
+-    def __init__(self, command, args=[], timeout=30, maxread=2000, searchwindowsize=None, logfile=None):
++    def __init__(self, command, args=[], timeout=30, maxread=2000, searchwindowsize=None, logfile=None, env=None):
+         """This is the constructor. The command parameter may be a string
+         that includes a command and any arguments to the command. For example:
+             p = pexpect.spawn ('/usr/bin/ftp')
+@@ -302,6 +302,7 @@
+         self.child_fd = -1 # initially closed
+         self.timeout = timeout
+         self.delimiter = EOF
++        self.env = env    
+         self.logfile = logfile    
+         self.maxread = maxread # Max bytes to read at one time into buffer.
+         self.buffer = '' # This is the read buffer. See maxread.
+@@ -421,7 +422,10 @@
+             # (specifically, Tomcat).
+             signal.signal(signal.SIGHUP, signal.SIG_IGN)
+ 
+-            os.execv(self.command, self.args)
++            if self.env is None:
++                os.execv(self.command, self.args)
++            else:
++                os.execve(self.command, self.args, self.env)
+ 
+         # Parent
+         self.terminated = 0

--- a/build/pkgs/pexpect/patches/pexpect.py-isdir_bug_fix.patch
+++ b/build/pkgs/pexpect/patches/pexpect.py-isdir_bug_fix.patch
@@ -1,5 +1,5 @@
---- pexpect.py	2007-04-16 07:08:24.000000000 -0700
-+++ ../../pexpect-2.0.p1.0/pexpect-2.0.p1/src/pexpect.py	2009-01-23 01:49:18.000000000 -0800
+--- a/pexpect.py	2007-04-16 07:08:24.000000000 -0700
++++ b/pexpect.py	2009-01-23 01:49:18.000000000 -0800
 @@ -1130,7 +1130,7 @@
      """
      # Special case where filename already contains a path.

--- a/build/pkgs/pexpect/spkg-install
+++ b/build/pkgs/pexpect/spkg-install
@@ -1,6 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-cd src/
+cd src
+
+# Apply patches
+for patch in ../patches/*.patch; do
+    patch -p1 <"$patch"
+    if [ $? -ne 0 ]; then
+        echo >&2 "Error applying '$patch'"
+        exit 1
+    fi
+done
 
 # On some systems pexpect doesn't upgrade correctly without
 # first removing the old version.


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12221">trac #12221</a>.

Reported by: jdemeyer

Component: interfaces

CC: cremona

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Georg S. Weber

Merged in: sage-5.0.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12221/12221_debug.patch">12221_debug.patch: </a> by jdemeyer at 20120112T11:01:12</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12221/test12221.sage">test12221.sage: </a> by jdemeyer at 20120112T15:59:31</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12221/pexpect-2.0.p4-p5.diff">pexpect-2.0.p4-p5.diff: Diff for the pexpect spkg, for review only</a> by jdemeyer at 20120113T10:04:31</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12221/12221_pexpect_unset_TERM.patch">12221_pexpect_unset_TERM.patch: </a> by jdemeyer at 20120120T13:41:13</li></ol>
