### PR TITLE
sqlite sometimes picks up the wrong libraries (e.g., readline) since we forgot to set LDFLAGS

### DIFF
--- a/build/pkgs/sqlite/SPKG.txt
+++ b/build/pkgs/sqlite/SPKG.txt
@@ -6,6 +6,9 @@ serverless, zero-configuration, transactional SQL database engine.
 == Upstream contact ==
  * URL: http://www.sqlite.org
 
+=== sqlite-3.7.5.p1 (William Stein, 10 May 2012) ===
+ * #12937: sqlite sometimes picks up the wrong libraries (e.g., readline) since we forgot to set LDFLAGS.  Thus, set LDFLAGS.
+
 === sqlite-3.7.5.p0 (Simon King, 10th December 2011) ===
  * #12131: Use --libdir, to make this package work on openSUSE
 

--- a/build/pkgs/sqlite/spkg-install
+++ b/build/pkgs/sqlite/spkg-install
@@ -41,6 +41,7 @@ fi
 export CFLAGS="$CFLAGS -O2 "
 export CXXFLAGS="$CXXFLAGS -O2 "
 export CPPFLAGS="$CPPFLAGS -I $SAGE_LOCAL/include"
+export LDFLAGS="$LDFLAGS -I $SAGE_LOCAL/lib"
 
 # There is no Fortran code in sqlite, but if FC is not set, there
 # there are annoying messages showing the use of the GNU fortran compiler
@@ -59,6 +60,7 @@ echo "                      CFLAGS=$CFLAGS"
 echo "                      CXXFLAGS=$CXXFLAGS"
 echo "                      FFLAGS=$FFLAGS"
 echo "                      CPPFLAGS=$CPPFLAGS"
+echo "                      LDFLAGS=$LDFLAGS"
 
 # Disable exit on error, since the necessary checks for errors
 # are below.


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12937">trac #12937</a>.

Diff for the sqlite spkg. For reference / review only.

Reported by: was

Component: packages

CC: 

Report Upstream: N/A

Authors: William Stein

Dependencies: 

Work issues: 

Reviewers: John Connor

Merged in: sage-5.1.beta1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12937/sqlite-3.7.5.p1.diff">sqlite-3.7.5.p1.diff: Diff for the sqlite spkg. For reference / review only.</a> by jdemeyer at 20120529T02:20:45</li></ol>
