### PR TITLE
gdmodule: don't use /sw and /usr/local paths

### DIFF
--- a/build/pkgs/gdmodule/patches/Setup.py.patch
+++ b/build/pkgs/gdmodule/patches/Setup.py.patch
@@ -7,7 +7,7 @@ diff -ru src/Setup.py b/Setup.py
  libdirs = dirtest([
 -    "/usr/local/lib", "/sw/lib", "/usr/lib",
 +    os.environ["SAGE_LOCAL"]+"/lib",
-+    "/usr/local/lib", "/usr/lib",
++    "/usr/lib",
      "/usr/lib/X11", "/usr/X11R6/lib",
      "/opt/gnome/lib",
  ])


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12909">trac #12909</a>.

Reported by: jdemeyer

Component: packages

CC: 

Report Upstream: N/A

Authors: Robert Bradshaw, Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Volker Braun

Merged in: sage-5.0.rc1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12909/gdmodule-0.56.p7-p8.diff">gdmodule-0.56.p7-p8.diff: </a> by jdemeyer at 20120507T15:19:32</li></ol>
