### PR TITLE
Work around GCC 4.7.0 bug on ia64 and improve the GMP-ECM spkg

### DIFF
--- a/build/pkgs/ecm/SPKG.txt
+++ b/build/pkgs/ecm/SPKG.txt
@@ -82,6 +82,11 @@ LGPL V2+
 
 == Changelog ==
 
+=== ecm-6.3.p7 (Leif Leonhardy, April 19th 2012) ===
+ * #12830: Add `-m[no-]power*` to the processor-specific options recognized;
+   these are used to enable/disable specific instruction set extensions of the
+   POWER and PowerPC (PPC) CPUs.
+
 === ecm-6.3.p6 (Leif Leonhardy, April 16th 2012) ===
  * #12830: Add a work-around for GCC 4.7.x on ia64 (Itanium), since GMP-ECM
    currently won't build with that and anything but `-O0` on that platform.

--- a/build/pkgs/ecm/spkg-install
+++ b/build/pkgs/ecm/spkg-install
@@ -176,7 +176,7 @@ else
         # 'native' not supported, see if GMP / MPIR provides us some CPU type:
         for opt in $gmp_cflags; do
             case $opt in
-                -march=*|-mcpu=*|-mtune*)
+                -march=*|-mcpu=*|-mtune=*|-mpower*|-mno-power*)
                     echo "Found CPU parameter in gmp.h: $opt"
                     cpu_params="$cpu_params $opt"
                     ;;
@@ -188,7 +188,7 @@ else
     rm -f foo.* foo
     # Only add them if CFLAGS do not already contain similar:
     if [ -n "$cpu_params" ] &&
-        ! (echo "$CFLAGS" | egrep -- '-march=|-mcpu=|-mtune=' >/dev/null);
+        ! (echo "$CFLAGS" | egrep -- '-march=|-mcpu=|-mtune=|-mpower|-mno-power' >/dev/null);
     then
         echo "Using additional host-specific CFLAGS: $cpu_params"
         CFLAGS="$cpu_params $CFLAGS"


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12830">trac #12830</a>.

Diff between my p6 and p7 spkgs.  For reference / review only.

Reported by: leif

Component: packages

CC: hedtke,, justin

Report Upstream: N/A

Authors: Leif Leonhardy

Dependencies: 

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.0.rc0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12830/ecm-6.3.p4-p5.diff">ecm-6.3.p4-p5.diff: Diff between the previous spkg in Sage and my new p5 spkg.  For reference / review only.</a> by leif at 20120411T11:25:28</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12830/ecm-6.3.p5-p6.diff">ecm-6.3.p5-p6.diff: Diff between my p5 and p6 spkgs.  For reference / review only.</a> by leif at 20120416T22:36:03</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12830/ecm-6.3.p4-p6.diff">ecm-6.3.p4-p6.diff: Diff between the previous spkg in Sage and my new p6 spkg.  For reference / review only.</a> by leif at 20120416T22:36:51</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12830/ecm-6.3.p6-p7.diff">ecm-6.3.p6-p7.diff: Diff between my p6 and p7 spkgs.  For reference / review only.</a> by leif at 20120419T14:19:13</li></ol>
