### PR TITLE
testcc.sh: allow $CC to contain multiple words

### DIFF
--- a/build/pkgs/libm4rie/SPKG.txt
+++ b/build/pkgs/libm4rie/SPKG.txt
@@ -30,6 +30,11 @@ GF(2^k) for 2 <= k <= 10.
 
 == Releases/Changelog ==
 
+=== libm4rie-20111004.p3 (Jeroen Demeyer, 10 April 2012) ===
+ * Trac #12821: don't quote $CC when running testcc.sh
+ * Use testcflags.sh to add -fPIC -Wall -pedantic -g
+ * Fix strings to test output of testcc.sh against
+
 === libm4rie-20111004.p2 (Jeroen Demeyer, 16 February 2012) ===
  * Rename source directory "m4rie" to "src".
  * Trac #12501: touch src/src/config.h.in to prevent autoheader from

--- a/build/pkgs/libm4rie/spkg-install
+++ b/build/pkgs/libm4rie/spkg-install
@@ -13,26 +13,23 @@ ROOT_DIR="`pwd`"
 INCLUDES="-I$SAGE_LOCAL/include"
 LIBDIRS="-L$SAGE_LOCAL/lib"
 
-CFLAGS="$CFLAGS $INCLUDES -g"
+CFLAGS="`testcflags.sh -fPIC -Wall -pedantic -g` $CFLAGS $INCLUDES"
 LDFLAGS="$LIBDIRS"
 
-COMPILER=`testcc.sh "$CC"`
-
-if [ "$COMPILER"  = "GNU" ] ; then
-    CFLAGS="$CFLAGS -fPIC -Wall -pedantic"
-elif [ "$COMPILER" = "Sun_on_Solaris" ] ; then
+COMPILER=`testcc.sh $CC`
+if [ "$COMPILER" = "Sun_Studio" ] ; then
     CFLAGS="$CFLAGS -Kpic"
-elif [ "$COMPILER" = "HP_on_HPUX" ] ; then
+elif [ "$COMPILER" = "HP_on_HP-UX" ] ; then
     CFLAGS="$CFLAGS + z"
 fi
 
 CPPFLAGS="$INCLUDES"
 
 if [ "x$SAGE_DEBUG" = "xyes" ]; then
-   CFLAGS="$CFLAGS -O0"
+   CFLAGS="-O0 $CFLAGS"
    ENABLE_DEBUG="--enable-debug"
 else
-   CFLAGS="$CFLAGS -O2"
+   CFLAGS="-O2 $CFLAGS"
    ENABLE_DEBUG=""
 fi
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12821">trac #12821</a>.

Reported by: jdemeyer

Component: build

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Leif Leonhardy, R. Andrew Ohana

Merged in: sage-5.1.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12821/libm4rie-20111004.p3.diff">libm4rie-20111004.p3.diff: </a> by jdemeyer at 20120410T08:47:05</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12821/12821_testcc.patch">12821_testcc.patch: </a> by jdemeyer at 20120525T05:04:41</li></ol>
