### PR TITLE
gfan 0.4plus [p1] fails to build with GCC 4.7.0

### DIFF
--- a/build/pkgs/gfan/SPKG.txt
+++ b/build/pkgs/gfan/SPKG.txt
@@ -47,8 +47,21 @@ refresh the prepatched files in `patches/`.
 TODO:
  * Use `patch` to apply patches (then also add GNU patch to the dependencies).
  * Clean up `spkg-install` further w.r.t. installation etc.
+ * Probably remove `CXXFLAG64` from the (patched) Makefile; instead put it
+   into `LDFLAGS` and use these in the Makefile.
+ * The Makefile is still suboptimal; e.g. Sage-specific values shouldn't be
+   hardcoded into it.  That way we could provide a clean patch for upstream,
+   and would later only have to change/set `make` variables in `spkg-install`,
+   without the need to patch the Makefile at all for Sage.
+   Also `CXXFLAGS` aren't used in, i.e. ignored by the current Makefile.
 
 == Changelog ==
+
+=== gfan-0.4plus.p3 (Leif Leonhardy, April 5th 2012) ===
+ * #12760: Fix erroneous unconditional export of `CXXFLAG64`, which is now in
+   the first place always set, and used in the patched Makefile.  (Also do not
+   export `CFLAG64`, which is only used within `spkg-install`.)
+ * Add further TODOs... ;-)
 
 === gfan-0.4plus.p2 (Leif Leonhardy, March 25th 2012) ===
  * #12760: Correct trivial C++ programming error to make gfan build with

--- a/build/pkgs/gfan/spkg-install
+++ b/build/pkgs/gfan/spkg-install
@@ -16,9 +16,14 @@ if [[ "$SAGE64" = yes ]]; then
     echo "Building a 64-bit version of gfan."
     CFLAGS="$CFLAGS $CFLAG64"
     CXXFLAGS="$CXXFLAGS $CXXFLAG64"
+    export CXXFLAG64 # Used in the patched Makefile.
+    # TODO: It would be much better to (also) modify LDFLAGS here and use
+    #       these instead in the Makefile when linking. (Cf. SPKG.txt.)
+else
+    unset CXXFLAG64 # Might come from the "global" environment.
 fi
 
-export CC CXX CFLAGS CFLAG64 CXXFLAGS CXXFLAG64
+export CC CXX CFLAGS CXXFLAGS
 
 # Patch the Makefile so it can build in Sage:
 echo "Copying a revised Makefile, to improve portability..."
@@ -38,15 +43,17 @@ if [[ $? -ne 0 ]]; then
     exit 1
 fi
 
+echo "Copying patched files to fix issues with GCC 4.5.0..."
 cp patches/linalg.cpp patches/matrix.h src/
 if [[ $? -ne 0 ]]; then
     echo >&2 "Error: Patch to fix GCC 4.5.0 issues did not copy correctly."
     exit 1
 fi
 
+echo "Copying patched file to fix an issue with GCC 4.7.0..."
 cp patches/app_minkowski.cpp src/
 if [[ $? -ne 0 ]]; then
-    echo >&2 "Error: Patch to fix GCC 4.7.0 issues did not copy correctly."
+    echo >&2 "Error: Patch to fix GCC 4.7.0 issue did not copy correctly."
     exit 1
 fi
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12760">trac #12760</a>.

Diff between my p2 and my p3 spkg.  For reference / review only.

Reported by: leif

Component: packages

CC: mhampton,, was,, mariah

Report Upstream: N/A

Authors: Leif Leonhardy

Dependencies: 

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.0.1.rc1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12760/gfan-0.4plus.p1-p2.diff">gfan-0.4plus.p1-p2.diff: Diff between the previous spkg in Sage and my new p2 spkg. For reference / review only.</a> by leif at 20120327T19:20:25</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12760/gfan-0.4plus.p1-p3.diff">gfan-0.4plus.p1-p3.diff: Diff between the previous spkg in Sage and my new p3 spkg. For reference / review only.</a> by leif at 20120406T00:05:53</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12760/gfan-0.4plus.p2-p3.diff">gfan-0.4plus.p2-p3.diff: Diff between my p2 and my p3 spkg.  For reference / review only.</a> by leif at 20120406T00:07:05</li></ol>
