### PR TITLE
Update PolyBoRi to release 0.8.1

### DIFF
--- a/build/pkgs/polybori/SPKG.txt
+++ b/build/pkgs/polybori/SPKG.txt
@@ -60,6 +60,7 @@ All patches were merged upstream.
 === polybori-0.8.1.p1 (Alexander Dreyer, March 26th, 2012) ===
  * Rebased spkg on polybori-0.8.0.p2 (Sage Trac #12750)
  * Working around broken scons on sun (Sage Trac #12655, comment:29)
+ * Added -Wno-long-long to CXXFLAGS (accompanying -std=c++98, comment:55)
 
 === polybori-0.8.1.p0 (Alexander Dreyer, March 7th, 2012) ===
  * Updating sources to PolyBoRi's release 0.8.1 (Sage Trac #12655)

--- a/build/pkgs/polybori/custom.py
+++ b/build/pkgs/polybori/custom.py
@@ -3,14 +3,14 @@ import sys
 
 # FIXME: Do we really want to *overwrite* the flags (e.g. if set by the user)?
 # Answer: Should be fixed now.
-CCFLAGS += ["-Wno-long-long", "-Wreturn-type"]
+CCFLAGS += ["-Wreturn-type"]
 
 # Note: PolyBoRi still appends DEFAULT_*FLAGS (overwrite those, if necessary)
 if 'CFLAGS' in os.environ:
   CFLAGS = os.environ['CFLAGS'].split(' ')
 
 if 'CXXFLAGS' in os.environ:
-  CXXFLAGS = os.environ['CXXFLAGS'].split(' ')
+  CXXFLAGS = ["-Wno-long-long"] + os.environ['CXXFLAGS'].split(' ')
 
 if 'CPPFLAGS' in os.environ:
   CCFLAGS = os.environ['CPPFLAGS'].split(' ')


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12655">trac #12655</a>.

!PolyBoRi's next minor release is out now.
There were no changes of the interface between !PolyBoRi 0.8.0 and 0.8.1, so we just have to update the sources from here:

https://sourceforge.net/projects/polybori/files/polybori/0.8.1

=== Current spkg ===
- **Install** http://boxen.math.washington.edu/home/dreyer/spkg/polybori-0.8.1.p1.spkg

This also fixes building with GCC-4.7.0, see <a href="http://trac.sagemath.org/sage_trac/ticket/12751">trac #12751</a> for the GCC-4.7.0 metaticket.

Reported by: AlexanderDreyer

Component: packages

CC: PolyBoRi,malb,burcin

Report Upstream: None of the above - read trac for reasoning.

Authors: Alexander Dreyer

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12656">trac #12656</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/12750">trac #12750</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/12799">trac #12799</a>

Work issues: 

Reviewers: Martin Albrecht, Jeroen Demeyer, Leif Leonhardy

Merged in: sage-5.0.beta13

Attachments: <ol></ol>
