### PR TITLE
cvxopt: fix illegal BLAS call and fix Solaris build

### DIFF
--- a/build/pkgs/cvxopt/SPKG.txt
+++ b/build/pkgs/cvxopt/SPKG.txt
@@ -38,10 +38,11 @@ GNU Lesser General Public License, v2.1.  See src/LICENSE for more details.
 
 == Special Update/Build Instructions ==
 
- * cvxopt.h.patch: TODO: document the reasons for this patch!
+ * cvxopt.h.patch: Fix building with GCC on Solaris.
 
- * setup.py.patch: look for ATLAS (etc.) in SAGE_ROOT/local/lib
-   instead of /usr/lib. TODO: more details for this patch.
+ * setup.py.patch: look for libraries and includes in $SAGE_LOCAL
+   instead of /usr.  Add fortran, blas,... libraries if needed.
+   Build with GSL and GLPK support.
 
  * dense.c.patch: this incorporates upstream changes from version
    1.1.5, fixing a bug to allow self-tests to pass on OS X 10.7
@@ -60,10 +61,13 @@ GNU Lesser General Public License, v2.1.  See src/LICENSE for more details.
 
 == Changelog ==
 
+=== cvxopt-1.1.4.p1 (Jeroen Demeyer, 3 April 2012) ===
+ * Trac #12011: edit cvxopt.h.patch to apply with all GCC versions.
+
 === cvxopt-1.1.4.p0 (John Palmieri, 31 March 2012) ===
  * Upgrade to version 1.1.4.
- * Trac #12011: apply upstream fix (from 1.1.5) to fix self-tests on
-   OS X Lion.
+ * Trac #12011: apply upstream fix (from 1.1.5) dense.c.patch to fix
+   self-tests on OS X Lion.
 
 === cvxopt-1.1.3.p1 (Jeroen Demeyer, 23 February 2012) ===
  * Trac #12519: Do not add -lcblas and -latlas on Darwin, since those

--- a/build/pkgs/cvxopt/patches/cvxopt.h.patch
+++ b/build/pkgs/cvxopt/patches/cvxopt.h.patch
@@ -1,36 +1,30 @@
---- src/src/C/cvxopt.h	2011-12-21 13:53:49.000000000 -0800
-+++ src.patched/src/C/cvxopt.h	2012-03-31 10:13:43.000000000 -0700
-@@ -27,8 +27,22 @@
+diff -ru src/src/C/cvxopt.h src.patched/src/C/cvxopt.h
+--- src/src/C/cvxopt.h	2011-12-21 22:53:49.000000000 +0100
++++ src.patched/src/C/cvxopt.h	2012-04-03 15:32:27.348269553 +0200
+@@ -27,8 +27,16 @@
  /* ANSI99 complex is disabled during build of CHOLMOD */
  
  #ifndef NO_ANSI99_COMPLEX
 -#include "complex.h"
--#define MAT_BUFZ(O)  ((complex *)((matrix *)O)->buffer)
-+
 +#include <complex.h>
-+/* work around Solaris 10 specific problem in complex.h */
-+ #if defined(__sun__) && defined(__GNUC__)
-+    #if __GNUC__ < 4  || ( __GNUC__ == 4 && __GNUC_MINOR__ < 5   )
-+ 
-+       #undef  _Complex_I
-+       #define _Complex_I (__extension__ 1.0iF)
-+ 
-+       #undef I
-+       #define I _Complex_I
-+ 
-+    #endif
-+ #endif
+ #define MAT_BUFZ(O)  ((complex *)((matrix *)O)->buffer)
 +
-+#define MAT_BUFZ(O)  ((complex *)((matrix *)O)->buffer)
++/* The <complex.h> header of Solaris 10 defines I in a way that GCC
++ * doesn't understand.  Redefine I like in glibc. */
++#if defined(__sun__) && defined(__GNUC__)
++    #undef I
++    #define I (__extension__ 1.0iF)
++#endif
++
  #endif
  
  #ifndef __CVXOPT__
-@@ -49,7 +63,7 @@
+@@ -49,7 +57,7 @@
    int_t strides[2];
    int_t ob_exports;
  #else
 -  int_t nrows, ncols;    /* number of rows and columns */
-+  int nrows, ncols;    /* number of rows and columns */
++  int nrows, ncols;      /* number of rows and columns */
  #endif
    int   id;              /* DOUBLE, INT, COMPLEX */
  } matrix;


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12011">trac #12011</a>.

Diff for the cvxopt spkg (p0->p1). For review only

Reported by: jhpalmieri

Component: packages

CC: dimpase,, vbraun

Report Upstream: Fixed upstream, in a later stable release.

Authors: Jeroen Demeyer, John Palmieri

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12519">trac #12519</a>

Work issues: 

Reviewers: Jeroen Demeyer, John Palmieri

Merged in: sage-5.0.beta13

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12011/trac_12011-cvxopt.patch">trac_12011-cvxopt.patch: patch for cvxopt spkg; for review only</a> by jhpalmieri at 20120331T18:56:19</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12011/cvxopt-1.1.4.p1.diff">cvxopt-1.1.4.p1.diff: Diff for the cvxopt spkg (p0->p1). For review only</a> by jdemeyer at 20120403T13:53:15</li></ol>
