### PR TITLE
elliptic_curves spkg is broken for system installs

### DIFF
--- a/build/pkgs/elliptic_curves/SPKG.txt
+++ b/build/pkgs/elliptic_curves/SPKG.txt
@@ -33,6 +33,9 @@ Includes two databases:
 
 == Changelog ==
 
+=== elliptic_curves-0.6 (R. Andrew Ohana, 2012-03-27) ===
+ * #12763: fix permissions for the installed files
+
 === elliptic_curves-0.5 (Keshav Kini, 2012-03-18) ===
  * #12694: make the spkg contain a src/ directory and track everything else
 

--- a/build/pkgs/elliptic_curves/spkg-install
+++ b/build/pkgs/elliptic_curves/spkg-install
@@ -81,6 +81,7 @@ def install_ellcurves():
             os.remove(old)
         else:
             shutil.move(f.name, endpath)
+        os.chmod(endpath, 0644)
 
 if __name__ == '__main__':
     install_cremona()


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12763">trac #12763</a>.

diff for the spkg, for review only

Reported by: rohana

Component: build

CC: 

Report Upstream: N/A

Authors: R. Andrew Ohana

Dependencies: 

Work issues: 

Reviewers: François Bissey

Merged in: sage-5.0.beta12

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12763/elliptic_curves-0.6.diff">elliptic_curves-0.6.diff: diff for the spkg, for review only</a> by rohana at 20120328T01:16:17</li></ol>
