### PR TITLE
In spkgs, run testcc.sh and testcxx.sh without explicit path

### DIFF
--- a/build/pkgs/rubiks/SPKG.txt
+++ b/build/pkgs/rubiks/SPKG.txt
@@ -22,6 +22,9 @@ Eric Dietz (GPL) http://www.wrongway.org/?rubiksource
 
 == Changelog ==
 
+=== rubiks-20070912.p18 (John Palmieri, 23 March 2012) ===
+ * #12311: Remove explicit path to testcc.sh in spkg-install.
+
 === rubiks-20070912.p17 (Jeroen Demeyer, 8 June 2011) ===
  * #11437: Apply workaround for versions 4.6.0 and 4.6.1 of gcc.
    The bug is supposed to be fixed in the final gcc 4.6.1 but we still

--- a/build/pkgs/rubiks/spkg-install
+++ b/build/pkgs/rubiks/spkg-install
@@ -15,7 +15,7 @@ set -e
 # Add a sensible default optimisation flag. Change if necessary.
 OPTIMIZATION_FLAGS="-O2"
 # Work around a bug in gcc 4.6.0: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=48702
-if [ "x`$SAGE_LOCAL/bin/testcc.sh $CC`" = xGCC ] ; then
+if [ "`testcc.sh $CC`" = GCC ] ; then
     if $CC -dumpversion 2>/dev/null |grep >/dev/null '^4\.6\.[01]$' ; then
         echo "Warning: Working around bug in gcc 4.6.0"
         OPTIMIZATION_FLAGS="$OPTIMIZATION_FLAGS -fno-ivopts"


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12311">trac #12311</a>.

patch for rubiks spkg; for review only

Reported by: jdemeyer

Component: packages

CC: 

Report Upstream: N/A

Authors: John Palmieri

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/11073">trac #11073</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/11920">trac #11920</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/12304">trac #12304</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/12694">trac #12694</a>

Work issues: 

Reviewers: Jeroen Demeyer

Merged in: sage-5.0.beta11

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12311/trac_12311-root.patch">trac_12311-root.patch: root repo</a> by jhpalmieri at 20120323T16:43:35</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12311/trac_12311-cliquer.patch">trac_12311-cliquer.patch: patch for cliquer spkg; for review only</a> by jhpalmieri at 20120323T16:43:53</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12311/trac_12311-libm4ri.patch">trac_12311-libm4ri.patch: patch for libm4ri spkg; for review only</a> by jhpalmieri at 20120323T20:42:17</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12311/trac_12311-rubiks.patch">trac_12311-rubiks.patch: patch for rubiks spkg; for review only</a> by jhpalmieri at 20120324T00:26:54</li></ol>
