### PR TITLE
Upgrade mpc and make it a standard package

### DIFF
--- a/build/pkgs/mpc/SPKG.txt
+++ b/build/pkgs/mpc/SPKG.txt
@@ -29,7 +29,18 @@ The MPC team can be contact via the MPC mailing list:
  * MPIR
  * MPFR
 
+== Special Update/Build Instructions ==
+
+Patches:
+ * no_fortify_source.patch: on some older systems, there are linker
+   errors when compiling MPC.  These go away when removing the compiler
+   flag "-D_FORTIFY_SOURCE=2", which is what the patch does.
+
 == Changelog ==
+
+=== mpc-1.0.0dev1126.p1 (Jeroen Demeyer, 23 March 2012) ===
+ * Trac #12515: add no_fortify_source.patch to remove compiler option
+   "-D_FORTIFY_SOURCE=2".
 
 === mpc-1.0.0dev1126 (Jeroen Demeyer, 22 February 2012) ===
  * Trac #12515: Upgrade to mpc-1.0.0, svn revision 1126

--- a/build/pkgs/mpc/patches/no_fortify_source.patch
+++ b/build/pkgs/mpc/patches/no_fortify_source.patch
@@ -1,0 +1,103 @@
+diff -ru mpc-1.0.0dev1126/m4/mpc.m4 mpc-1.0.0dev1126M/m4/mpc.m4
+--- mpc-1.0.0dev1126/m4/mpc.m4	2012-03-22 15:02:41.000000000 +0100
++++ mpc-1.0.0dev1126M/m4/mpc.m4	2012-03-23 14:08:42.000000000 +0100
+@@ -91,10 +91,6 @@
+   AC_REQUIRE([AC_PROG_GREP])
+   if echo $VERSION | grep -c dev >/dev/null 2>&1 ; then
+     if test "x$GCC" = "xyes" -a "x$compiler" != "xicc" -a "x$compiler" != "xg++"; then
+-      case $host in
+-         *darwin*) ;;
+-         *) MPC_C_CHECK_FLAG(-D_FORTIFY_SOURCE=2,$1) ;;
+-      esac
+       MPC_C_CHECK_FLAG(-g)
+       MPC_C_CHECK_FLAG(-std=c99)
+       MPC_C_CHECK_FLAG(-pedantic)
+diff -ru mpc-1.0.0dev1126/configure mpc-1.0.0dev1126M/configure
+--- mpc-1.0.0dev1126/configure	2012-03-23 10:05:22.000000000 +0100
++++ mpc-1.0.0dev1126M/configure	2012-03-23 14:08:55.000000000 +0100
+@@ -11630,85 +11630,6 @@
+ 
+   if echo $VERSION | grep -c dev >/dev/null 2>&1 ; then
+     if test "x$GCC" = "xyes" -a "x$compiler" != "xicc" -a "x$compiler" != "xg++"; then
+-      case $host in
+-         *darwin*) ;;
+-         *)
+-
+-
+-
+-
+-
+-  flag=`echo "-D_FORTIFY_SOURCE=2" | $SED 'y% .=/+-(){}<>:*,%_______________%'`
+-
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler accepts the -D_FORTIFY_SOURCE=2 flag" >&5
+-$as_echo_n "checking whether the C compiler accepts the -D_FORTIFY_SOURCE=2 flag... " >&6; }
+-if eval \${ax_cv_c_check_flag_$flag+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-
+-
+-    ac_ext=c
+-ac_cpp='$CPP $CPPFLAGS'
+-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_c_compiler_gnu
+-
+-
+-    save_CFLAGS="$CFLAGS"
+-    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2"
+-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-
+-_ACEOF
+-if ac_fn_c_try_compile "$LINENO"; then :
+-
+-      eval "ax_cv_c_check_flag_$flag=yes"
+-
+-else
+-
+-      eval "ax_cv_c_check_flag_$flag=no"
+-
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-
+-    CFLAGS="$save_CFLAGS"
+-
+-    ac_ext=c
+-ac_cpp='$CPP $CPPFLAGS'
+-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+-ac_compiler_gnu=$ac_cv_c_compiler_gnu
+-
+-
+-
+-fi
+-eval ac_res=\$ax_cv_c_check_flag_$flag
+-	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+-$as_echo "$ac_res" >&6; }
+-
+-  if eval "test \"`echo '$ax_cv_c_check_flag_'$flag`\" = yes"; then :
+-
+-    :
+-    CFLAGS="$CFLAGS -D_FORTIFY_SOURCE=2"
+-
+-else
+-
+-    :
+-
+-
+-fi
+-
+- ;;
+-      esac
+ 
+ 
+ 

--- a/build/pkgs/mpc/spkg-install
+++ b/build/pkgs/mpc/spkg-install
@@ -11,6 +11,16 @@ unset RM
 
 cd src
 
+# Apply patches.  See SPKG.txt for information about what each patch
+# does.
+for patch in ../patches/*.patch; do
+    patch -p1 <"$patch"
+    if [ $? -ne 0 ]; then
+        echo >&2 "Error applying '$patch'"
+        exit 1
+    fi
+done
+
 # Unset CC and CFLAGS.  This will make mpc use the same configuration
 # as MPIR, which is probably a good thing.
 unset CC


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12515">trac #12515</a>.

Diff for mpc-1.0.0dev1126.p1.spkg, for review only

Reported by: jdemeyer

Component: packages

CC: jpflori,, leif

Report Upstream: Fixed upstream, but not in a stable release.

Authors: Jeroen Demeyer

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/10492">trac #10492</a>, <a href="http://trac.sagemath.org/sage_trac/ticket/12223">trac #12223</a>

Work issues: 

Reviewers: Jean-Pierre Flori, Volker Braun

Merged in: sage-5.0.beta13

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12515/12515_mpc_sage_root.patch">12515_mpc_sage_root.patch: </a> by jdemeyer at 20120216T09:34:47</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12515/12515_mpc_standard.patch">12515_mpc_standard.patch: </a> by jdemeyer at 20120216T09:37:22</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12515/12515_norm.patch">12515_norm.patch: </a> by jdemeyer at 20120220T12:37:55</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12515/mpc-1.0.0dev1126.diff">mpc-1.0.0dev1126.diff: Diff for the mpc spkg (w.r.t. the latest optional mpc spkg), for review only</a> by jdemeyer at 20120224T14:57:01</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12515/mpc-1.0.0dev1126.p1.diff">mpc-1.0.0dev1126.p1.diff: Diff for mpc-1.0.0dev1126.p1.spkg, for review only</a> by jdemeyer at 20120323T12:16:01</li></ol>
