### PR TITLE
Cloning doesn't properly copy the _static doc directory

### DIFF
--- a/src/bin/sage-clone
+++ b/src/bin/sage-clone
@@ -71,21 +71,23 @@ print "Copying over all auto-generated reference manual .rst files..."
 sys.path.append(os.environ['SAGE_DOC'])
 from common.builder import LANGUAGES
 for lang in LANGUAGES:
+    ref = os.path.join('sage', 'doc', lang, 'reference')
     try:
-        for directory in ['sage', 'sagenb']:
-            fr = os.path.join('sage', 'doc', lang, 'reference', directory)
-            if os.path.exists(fr):
-                to = os.path.join(branch, 'doc', lang, 'reference', directory)
-                cmd = 'cp -pR %s %s' % (fr, to)
-#                print cmd
-                subprocess.call([cmd], shell=True)
-#        shutil.copytree(os.path.join('sage/doc', lang, 'reference/sage'),
-#                        os.path.join(branch, 'doc', lang, 'reference/sage'))
+        for f in os.listdir(ref):
+            if os.path.isdir(os.path.join(ref, f)):
+                for directory in ['sage', 'sagenb']:
+                    fr = os.path.join(ref, f, directory)
+                    if os.path.exists(fr):
+                        to = os.path.join(branch, 'doc', lang, 'reference', f, directory)
+                        cmd = 'cp -pR %s %s' % (fr, to)
+                        subprocess.call([cmd], shell=True)
     except:
         pass
 
 print "Copying over documentation output..."
-copy_dtree('sage/doc/output', branch + '/doc/output')
+# Use shutil.copytree instead of copy_dtree to make sure that symlinks
+# are copied correctly. See #14245.
+shutil.copytree('sage/doc/output', branch + '/doc/output', symlinks=True)
 
 print "Building " + branch + "..."
 cmd = 'sage -b %s'%sys.argv[1]


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14245">trac #14245</a>.

scripts repo

Reported by: hivert

Component: documentation

CC: jhpalmieri,, leif,, niles,, hivert,, mguaypaq,, mhansen

Report Upstream: N/A

Authors: John Palmieri

Dependencies: 

Work issues: 

Reviewers: Florent Hivert

Merged in: sage-5.8.rc0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14245/trac_14245_clone.patch">trac_14245_clone.patch: scripts repo</a> by jhpalmieri at 20130310T23:34:34</li></ol>
