### PR TITLE
Add double clicking of sws files for Mac app

### DIFF
--- a/src/bin/sage-bdist
+++ b/src/bin/sage-bdist
@@ -126,8 +126,7 @@ if [ "$UNAME" = "Darwin" ]; then
         # I would just change it to be an xml plist, but xcode changes it back.
         plutil -convert xml1 ./Sage.app/Contents/Info.plist
         sed -i '' "s/SAGE_VERSION/$SAGE_VERSION/" \
-            ./Sage.app/Contents/Info.plist \
-            ./Sage.app/Contents/Resources/English.lproj/InfoPlist.strings
+            ./Sage.app/Contents/Info.plist
 
         mv sage ./Sage.app/Contents/Resources/
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/11026">trac #11026</a>.

Reported by: iandrus

Component: user interface

CC: kcrisman,, jhpalmieri

Report Upstream: N/A

Authors: Ivan Andrus

Dependencies: 

Work issues: 

Reviewers: Karl-Dieter Crisman, Nicholas Kirchner, John Palmieri

Merged in: sage-5.8.beta0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/11026/trac_11026-extcode-rebase.patch">trac_11026-extcode-rebase.patch: Based on 5.1beta1</a> by kcrisman at 20120706T00:03:33</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/11026/trac_11026-extcode-rebase.2.patch">trac_11026-extcode-rebase.2.patch: Based on 5.1.beta1</a> by kcrisman at 20120710T18:16:16</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/11026/trac_11026-extcode.patch">trac_11026-extcode.patch: </a> by iandrus at 20120712T12:44:34</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/11026/trac_11026-fix-parse-error.patch">trac_11026-fix-parse-error.patch: </a> by iandrus at 20130118T12:24:38</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/11026/trac_11026-warnings.patch">trac_11026-warnings.patch: </a> by iandrus at 20130212T21:54:38</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/11026/trac_11026-plist-strings.patch">trac_11026-plist-strings.patch: </a> by iandrus at 20130212T21:58:19</li></ol>
