### PR TITLE
Fix sage-coverage

### DIFF
--- a/src/bin/sage-coverage
+++ b/src/bin/sage-coverage
@@ -1,172 +1,212 @@
 #!/usr/bin/env python
 
-import os, sys, re
+from __future__ import print_function
+
+import os
+import sys
+import token
+from tokenize import *
 
 if len(sys.argv) == 1:
-    print "Usage: sage -coverage <files>"
-    print "Give info about doctest coverage of files."
-    sys.exit(1)
+    print("Usage: sage --coverage <files>")
+    print("Give info about doctest coverage of files.")
+    sys.exit(2)
 
-if len(sys.argv) == 2 and sys.argv[-1] == '.':
-    sys.exit(os.system("sage-coverageall ."))
+# Collect coverage results for one file
+class CoverageResults:
+    def __init__(self, filename=""):
+        """
+        INPUT:
 
-def functions_without_doctests(file):
-    docs  = []
-    tests = []
-    good  = []
-    possibly_wrong = []
-    closures = []  # functions nested within others -- ignore when computing coverage
-    indentation = 0
-    cython = re.search('c[p]?def', file)  # true if it looks like a cython file
-    df = re.compile('def\s+\w')
-    ee = re.compile('\)\s*:')
-    while True:
-        i = df.search(file)
-        if i is None:
-            break
-        i = i.start()
+        - ``filename`` -- name of the file, only for display purposes.
+        """
+        self.no_doc = []
+        self.no_test = []
+        self.good = []
+        self.possibly_wrong = []
+        self.filename = filename
 
-        m = ee.search(file[i:])
-        if m is None:
-            break
-        j = m.end() + i
+    def report(self):
+        """
+        Print coverage results.
+        """
+        num_functions = len(self.good) + len(self.no_doc) + len(self.no_test)
+        if not num_functions:
+            print("No functions in", self.filename)
+            return
 
-        z = file[:i].rfind('\n')
-        if z != -1:
-            prev = file[z:i]
+        score = (100.0 * len(self.good)) / float(num_functions)
 
-            # Skip line if it is commented out.
-            if prev.lstrip().startswith('#'):
-                file = file[:i] + file[j:]
-                continue
+        print("SCORE {}: {:.1f}% ({} of {})".format(self.filename, score, len(self.good), num_functions))
 
-            #Skip functions which are defined in doctests
-            if 'sage:' in prev or '...' in prev:
-                file = file[:i] + file[j:]
-                continue
+        if self.no_doc:
+            print("\nMissing documentation:")
+            for f in self.no_doc:
+                print("     *", f)
+        if self.no_test:
+            print("\nMissing doctests:")
+            for f in self.no_test:
+                print("     *", f)
 
-        function_name = ' '.join(file[i:j].lstrip('def').split())
-        bare_function_name = function_name[:function_name.find("(")]
-        # Take the last word of the bare function name, to support
-        # Cython/Python functions like "cpdef long foo()".  The bare
-        # function name should be "foo", not "long foo".
-        bare_function_name = bare_function_name.split()[-1]
+        if self.possibly_wrong:
+            print("\nPossibly wrong (function name doesn't occur in doctests):")
+            for f in self.possibly_wrong:
+                print("     *", f)
 
-        if i > 0 and file[i-1] in ['c', 'e']: # and ('\n' in file[i:j] or '(' not in file[i:j]):
-            file = file[i+10:]
-            continue
-        skip_this = False
-        for skip in ['__dealloc__', '__new__', '_']:
-            if function_name.startswith(skip + '('):
-                file = file[j:]
-                skip_this = True
-                break
+    def handle_function(self, name, fullname, docstring):
+        """
+        Check coverage of one function and store result.
 
-        new_indentation = file[z:i].count(' ')
-        # try to determine if this is a closure (i.e., nested function).
-        # don't worry about cython files, just plain python.
-        if not cython:
-            clss = re.search("^\s*(cdef)?\s*class\s+", file[:i], re.M)
-            if not clss:  # not the first function after a class definition
-                # if indented more than current indentation level, it's a closure
-                if new_indentation > indentation:
-                    file = file[i+2:]
-                    closures.append(function_name)
-                    skip_this = True
+        INPUT:
 
-        if skip_this:
-            continue
+        - ``name`` -- bare function name (e.g. "foo")
 
-        # number of spaces this def is indented.  use this to check if
-        # the next def is nested.
-        indentation = new_indentation
+        - ``fullname`` -- complete function definition (e.g. "def foo(arg=None)")
 
-        k = file[j:].find('\n')
-        if k == -1:
-            break
-        k += j
-        kk = file[k+1:].find('\n')
-        if kk == -1:
-            break
-        kk += k+1
+        - ``docstring`` -- the docstring, or ``None`` if there is no docstring
+        """
+        # Skip certain names
+        if name in ['__dealloc__', '__new__', '_']:
+            return
 
-        q0 = file[k:kk].find('"""')
-        if q0 == -1:
-            docs.append(function_name)
+        if not docstring:
+            self.no_doc.append(fullname)
+            return
+        if not "sage: " in docstring:
+            self.no_test.append(fullname)
+            return
+
+        # If the name is of the form _xxx_, then the doctest is always
+        # considered indirect.
+        if name[0] == "_" and name[-1] == "_":
+            is_indirect = True
         else:
-            q0 += k
-            q1 = file[q0+3:].find('"""')
-            if q1 == -1:
-                print "Error parsing %s"%function_name
-            else:
-                q1 += q0 + 3
-                d = file[q0:q1].find('sage:')
-                if d == -1:
-                    tests.append(function_name)
+            is_indirect = "indirect doctest" in docstring
+
+        if not is_indirect and not name in docstring:
+            self.possibly_wrong.append(fullname)
+        self.good.append(fullname)
+
+    def check_file(self, f):
+        """
+        Check the coverage of one file.
+
+        INPUT:
+
+        - ``f``: an open file
+
+        OUTPUT: ``self``
+        """
+        # Where are we in a function definition?
+        BEGINOFLINE = 0   # Beginning of new logical line
+        UNKNOWN = -99     # Not at all in a function definition
+        DEFNAMES = 1      # In function definition before first open paren
+        DEFARGS = 2       # In function arguments or between closing paren and final colon
+        DOCSTRING = -1    # Looking for docstring
+
+        state = BEGINOFLINE
+
+        # Previous token type seen
+        prevtyp = NEWLINE
+
+        # Indentation level
+        indent = 0
+
+        # Indentation level of last "def" statement
+        # or None if no such statement.
+        defindent = None
+
+        for (typ, tok, start, end, logical_line) in generate_tokens(f.readline):
+            # Completely ignore comments or continuation newlines
+            if typ == COMMENT or typ == NL:
+                continue
+
+            # Handle indentation
+            if typ == INDENT:
+                indent += 1
+                continue
+            elif typ == DEDENT:
+                indent -= 1
+                if (defindent is not None and indent <= defindent):
+                    defindent = None
+                continue
+
+            # Check for "def" or "cpdef" ("cdef" functions don't need to be documented).
+            # Skip nested functions (with indent > defindent).
+            if state == BEGINOFLINE:
+                if typ == NAME and (tok in ["def", "cpdef"]) and (defindent is None or indent <= defindent):
+                    state = DEFNAMES
+                    deffullname = "line %s: "%start[0]
+                    defparen = 0  # Number of open parentheses
                 else:
-                    good.append(function_name)
-                    if not (bare_function_name[0:2] == '__' and
-                        bare_function_name[-2:] == '__'):
-                        d = file[q0:q1].find(bare_function_name)
-                        e = file[q0:q1].find('indirect doctest')
-                        if d == -1 and e == -1:
-                            possibly_wrong.append(function_name)
+                    state = UNKNOWN
 
-        file = file[j+3:]
-    #end while
-    #docs.sort()
-    #tests.sort()
-    #good.sort()
-    return docs, tests, good, possibly_wrong
+            if state == DOCSTRING:
+                if typ != NEWLINE:
+                    docstring = None
+                    if typ == STRING:
+                        docstring = tok
+                    self.handle_function(defname, deffullname, docstring)
+                    state = UNKNOWN
 
-def coverage(filename, file):
-    docs, tests, good, possibly_wrong = functions_without_doctests(file)
-    num_functions = len(good+docs+tests)
-    if num_functions == 0:
-        print "No functions in %s"%filename
-        return
+            if state == DEFNAMES:
+                if typ == NAME:
+                    if tok == "class":  # Make sure that cdef classes are ignored
+                        state = UNKNOWN
+                    # Last NAME token before opening parenthesis is
+                    # the function name.
+                    defname = tok
+                elif tok == '(':
+                    state = DEFARGS
+                else:
+                    state = UNKNOWN
 
-    #print os.path.abspath(filename)
-    print '-'*70
-    print filename
-    score = 100 * (len(good)) / float(num_functions)
-    score = int(score)
+            if state == DEFARGS:
+                if tok == '(':
+                    defparen += 1
+                elif tok == ')':
+                    defparen -= 1
+                elif defparen == 0 and tok == ':':
+                    state = DOCSTRING
+                    defindent = indent
+                elif typ == NEWLINE:
+                    state = UNKNOWN
 
-    if re.search("^\s*(cdef)?\s*class\s+", file, re.M) and 'loads' not in file and 'TestSuite(' not in file:
-        print "ERROR: Please add a `TestSuite(s).run()` doctest."
+            if state > 0:
+                # Append tok string to deffullname
+                if prevtyp == NAME and typ == NAME:
+                    deffullname += ' '
+                elif prevtyp == OP and deffullname[-1] in ",":
+                    deffullname += ' '
+                deffullname += tok
 
-    if score < 0:
-        score = 0
+            # New line?
+            if state == UNKNOWN and typ == NEWLINE:
+                state = BEGINOFLINE
 
-    print "SCORE %s: %s%% (%s of %s)"%(filename, score, len(good), num_functions)
+            prevtyp = typ
 
-    if docs:
-        print "\nMissing documentation:\n\t * %s\n"%('\n\t * '.join(docs))
-    if tests:
-        print "\nMissing doctests:\n\t * %s\n"%('\n\t * '.join(tests))
+        return self
 
-    if possibly_wrong:
-        print "\nPossibly wrong (function name doesn't occur in doctests):\n" + \
-              "\t * %s\n"%('\n\t * '.join(possibly_wrong))
+first = True
 
-    print '-'*70
-
-def go(file):
-    if os.path.isdir(file):
-        for F in os.listdir(file):
-            go('%s/%s'%(file,F))
-        return
-    if 'doctest_' in file or file.endswith('~'):
-        return
-    if not (file.endswith('.py') or file.endswith('.pyx')):
-        return
-    if not os.path.exists(file):
-        print "File %s does not exist."%file
+def go(filename):
+    if os.path.isdir(filename):
+        for F in sorted(os.listdir(filename)):
+            go(os.path.join(filename, F))
+    if not os.path.exists(filename):
+        print("File %s does not exist."%filename, file=sys.stderr)
         sys.exit(1)
 
-    f = open(file).read()
-    coverage(file, f)
-    print ""
+    if not (filename.endswith('.py') or filename.endswith('.pyx')):
+        return
 
-for file in sys.argv[1:]:
-    go(file)
+    global first
+    if first:
+        print('-'*72)
+        first = False
+    CoverageResults(filename).check_file(open(filename)).report()
+    print('-'*72)
+
+for arg in sys.argv[1:]:
+    go(arg)

--- a/src/bin/sage-coverageall
+++ b/src/bin/sage-coverageall
@@ -4,7 +4,7 @@ import os, sys
 
 def coverage_all(directory):
     os.chdir(directory)
-    r = os.popen('sage -coverage * | grep SCORE').readlines()
+    r = os.popen('sage-coverage * | grep SCORE').readlines()
 
     s = []
     scr = 0
@@ -17,7 +17,7 @@ def coverage_all(directory):
 
         i = y.rfind(':')
         j = y.rfind('%')
-        scr += int(y[i+1:j]) * float(n)
+        scr += float(y[i+1:j]) * float(n)
 
         total += n
 
@@ -35,12 +35,12 @@ def coverage_all(directory):
 
     # Print up to 3 doctest coverage goals.
     i = 0
-    for goal in [68, 70, 75, 80, 85, 90, 95, 99]:
+    for goal in [70, 75, 80, 85, 90, 95, 99]:
         if score < goal:
             i += 1
             if i > 3: break
             need = int((goal*total - scr)/100.0)
-            print "We need %4s more function to get to %s%% coverage."%(need,goal)
+            print "We need %4s more function%s to get to %s%% coverage."%(need, "" if (need == 1) else "s", goal)
 
 if len(sys.argv) == 1:
     coverage_all('%s/devel/sage/sage/'%os.environ["SAGE_ROOT"])


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/14061">trac #14061</a>.

Reported by: jdemeyer

Component: scripts

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Travis Scrimshaw

Merged in: sage-5.7.beta4

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14061/coverage.diff">coverage.diff: Diff of coverageall results</a> by jdemeyer at 20130205T17:07:32</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/14061/coverage_using_tokens.patch">coverage_using_tokens.patch: </a> by jdemeyer at 20130205T20:54:56</li></ol>
