### PR TITLE
nose testing suite as an optional spkg

### DIFF
--- a/src/bin/.hgignore
+++ b/src/bin/.hgignore
@@ -331,6 +331,7 @@ PolyGUI
 cygdb
 ppl-config
 ppl_pips
+nosetests*
 webassets
 phc
 pybtex


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/9921">trac #9921</a>.

patch for spkg, for review only (version 1.1.3)

Reported by: jason

Component: optional packages

CC: drkirkby,, jhpalmieri

Report Upstream: N/A

Authors: John Palmieri

Dependencies: 

Work issues: 

Reviewers: Karl-Dieter Crisman, Martin Raum

Merged in: sage-5.7.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9921/trac_9921-nose-scripts.patch">trac_9921-nose-scripts.patch: scripts repo</a> by jhpalmieri at 20120614T23:19:08</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9921/trac_9921-nose-spkg.patch">trac_9921-nose-spkg.patch: patch for spkg, for review only</a> by jhpalmieri at 20120614T23:39:10</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9921/trac_9921-nose-spkg.git.patch">trac_9921-nose-spkg.git.patch: patch for spkg, for review only (version 1.1.3)</a> by jhpalmieri at 20120614T23:39:24</li></ol>
