### PR TITLE
sage -gdb ImportError

### DIFF
--- a/src/bin/sage-gdb
+++ b/src/bin/sage-gdb
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-PYTHONSTARTUP=$SAGE_ROOT/local/bin/sage-ipython
-export PYTHONSTARTUP
-echo $PYTHONSTARTUP
-gdb -x $SAGE_ROOT/local/bin/sage-gdb-commands -args python -i


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13669">trac #13669</a>.

Updated patch

Reported by: vbraun

Component: scripts

CC: jdemeyer

Report Upstream: N/A

Authors: Volker Braun

Dependencies: 

Work issues: 

Reviewers: Simon King

Merged in: sage-5.6.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13669/trac_13669_bin_remove_sage-gdb.patch">trac_13669_bin_remove_sage-gdb.patch: Initial patch</a> by vbraun at 20121030T13:00:33</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13669/trac_13669_fix_sage_gdb.patch">trac_13669_fix_sage_gdb.patch: Updated patch</a> by vbraun at 20121229T20:12:02</li></ol>
