### PR TITLE
Add ccache as an optional spkg

### DIFF
--- a/src/bin/.hgignore
+++ b/src/bin/.hgignore
@@ -44,6 +44,7 @@ bzip2recover
 bzless
 bzmore
 bzr
+ccache
 cdd_both_reps
 cdd_both_reps_gmp
 cftp


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/13032">trac #13032</a>.

Apply to SAGE_ROOT

Reported by: rohana

Component: optional packages

CC: kini,, robertwb,, ppurka,, jdemeyer

Report Upstream: N/A

Authors: R. Andrew Ohana

Dependencies: 

Work issues: 

Reviewers: Punarbasu Purkayastha

Merged in: sage-5.6.beta2

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13032/trac13032_scripts.patch">trac13032_scripts.patch: apply to scripts repo</a> by rohana at 20120620T08:07:26</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13032/trac13032_doc.patch">trac13032_doc.patch: apply to sage library</a> by rohana at 20120912T21:24:44</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13032/trac13032_root.patch">trac13032_root.patch: apply to root repo</a> by rohana at 20120912T23:38:43</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/13032/trac13032_root.1.patch">trac13032_root.1.patch: Apply to SAGE_ROOT</a> by ppurka at 20121226T05:38:23</li></ol>
