### PR TITLE
Add some patches to the PARI sources

### DIFF
--- a/build/pkgs/pari/SPKG.txt
+++ b/build/pkgs/pari/SPKG.txt
@@ -79,6 +79,10 @@ exactly where it says native, but I would expect a grep to find it.
 
 == Changelog ==
 
+=== pari-2.5.1.p3 (Jeroen Demeyer, 20 March 2012) ===
+ * Ticket #12638: add upstream patch pari_1304.patch for issquarefree(0),
+   see http://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=1304
+
 === pari-2.5.1.p2 (Jeroen Demeyer, 13 March 2012) ===
  * Ticket #12638: add upstream patch pari_1302.patch for ispower(),
    see http://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=1302

--- a/build/pkgs/pari/patches/README.txt
+++ b/build/pkgs/pari/patches/README.txt
@@ -54,6 +54,10 @@ C files:
 * pari_1302.patch: Add a patch (from upstream's git master) to make
   ispower() work properly for negative integers.  See
   http://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=1302
+* pari_1304.patch: Add a patch (from upstream's git master, with the
+  patch to CHANGES removed) to make issquarefree(0) return 0 instead of
+  raising an error.  See
+  http://pari.math.u-bordeaux.fr/cgi-bin/bugreport.cgi?bug=1304
 
 ======================================================================
 Files previously patched:

--- a/build/pkgs/pari/patches/pari_1304.patch
+++ b/build/pkgs/pari/patches/pari_1304.patch
@@ -1,0 +1,39 @@
+commit ff707a3f2ba2d5c555434ba50547453833a7570f
+Author: Karim Belabas <Karim.Belabas@math.u-bordeaux1.fr>
+Date:   Sun Mar 18 23:54:02 2012 +0100
+
+    71- issquarefree(0) => error [#1304]
+
+diff --git a/src/basemath/ifactor1.c b/src/basemath/ifactor1.c
+index 046491f..8f9fbaa 100644
+--- a/src/basemath/ifactor1.c
++++ b/src/basemath/ifactor1.c
+@@ -3493,7 +3493,11 @@ moebius(GEN n)
+ GEN
+ gissquarefree(GEN x) { return map_proto_lG(issquarefree,x); }
+ long
+-Z_issquarefree(GEN n) { return moebius(n)? 1: 0; }
++Z_issquarefree(GEN n)
++{
++  if (!signe(n)) return 0;
++  return moebius(n)? 1: 0;
++}
+ long
+ issquarefree(GEN x)
+ {
+diff --git a/src/test/32/arith b/src/test/32/arith
+new file mode 100644
+index 0000000..3c5981a
+--- /dev/null
++++ b/src/test/32/arith
+@@ -0,0 +1,2 @@
++0
++Total time spent: 8
+diff --git a/src/test/in/arith b/src/test/in/arith
+new file mode 100644
+index 0000000..fb92bed
+--- /dev/null
++++ b/src/test/in/arith
+@@ -0,0 +1,2 @@
++\\#1304
++issquarefree(0)


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12638">trac #12638</a>.

Diff for the PARI spkg (p0->p3). For review only

Reported by: jdemeyer

Component: packages

CC: 

Report Upstream: Reported upstream. Developers acknowledge bug.

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Johan Bosman

Merged in: sage-5.0.beta12

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12638/pari-2.5.1.p3.diff">pari-2.5.1.p3.diff: Diff for the PARI spkg (p0->p3). For review only</a> by jdemeyer at 20120320T13:53:12</li></ol>
