### PR TITLE
Multimodular echelon form over cyclotomic fields fails

### DIFF
--- a/build/pkgs/linbox/SPKG.txt
+++ b/build/pkgs/linbox/SPKG.txt
@@ -24,6 +24,9 @@ LGPL V2 or later
 
 == Changelog ==
 
+=== linbox-1.1.6.p8 (William Stein, 18 March 2012) ===
+ * Trac #10281: Multimodular echelon form over cyclotomic fields fails
+
 === linbox-1.1.6.p7 (Jeroen Demeyer, 5 March 2012) ===
  * Trac #12629: *always* disable the commentator.  There are problems
    om some systems (e.g. OS X 10.4 with GCC 4.6.3) when parts of LinBox

--- a/build/pkgs/linbox/patches/linbox-sage.patch
+++ b/build/pkgs/linbox/patches/linbox-sage.patch
@@ -1,0 +1,13 @@
+--- src/interfaces/sage/linbox-sage.h	2008-06-13 18:20:42.000000000 -0700
++++ /home/wstein/linbox-sage.h	2012-03-18 08:22:21.359257410 -0700
+@@ -31,7 +31,9 @@
+ #endif
+ 
+ #include<stddef.h>
+-typedef size_t mod_int; 
++
++#include <stdint.h>
++typedef uint_fast64_t mod_int;
+ 
+ #include <cstdlib>
+ #include <vector>


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/10281">trac #10281</a>.

This patch is for beta9.  I've made the one change that robertwb suggests to this patch (the formal cython change)

Reported by: mraum

Component: linear algebra

CC: 

Report Upstream: N/A

Authors: William Stein

Dependencies: 

Work issues: 

Reviewers: Martin Raum

Merged in: sage-5.0.beta14

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/10281/trac_10281-sage-5.0-beta9.patch">trac_10281-sage-5.0-beta9.patch: This patch is for beta9.  I've made the one change that robertwb suggests to this patch (the formal cython change)</a> by was at 20120318T12:49:26</li></ol>
