### PR TITLE
Fix "hardcoded" 'gcc' in ratpoints 2.1.3 [p2]

### DIFF
--- a/build/pkgs/ratpoints/SPKG.txt
+++ b/build/pkgs/ratpoints/SPKG.txt
@@ -2,9 +2,10 @@
 
 == Description ==
 
-Michael Stoll's program which searches for rational points on hyperelliptic curves.
+Michael Stoll's program which searches for rational points on hyperelliptic
+curves.
 
-== Maintainers ==
+== SPKG Maintainers ==
 
  * Robert Miller
 
@@ -16,15 +17,28 @@ Michael Stoll's program which searches for rational points on hyperelliptic curv
 
 == Dependencies ==
 
- * MPIR
+ * GMP/MPIR
+ * (GNU) patch
 
-== Distribution ==
+== Special Update/Build Instructions ==
 
 === Note on SSE2 instructions ===
 
- * On several architectures, the SSE2 instructions used by ratpoints cause compiler errors. In the case that ratpoints fails to build with SSE2 instructions enabled, the build is repeated with SSE2 disabled.
+ * On several architectures, the SSE2 instructions used by ratpoints cause
+   compiler errors.  In the case that ratpoints fails to build with SSE2
+   instructions enabled, the build is repeated with SSE2 disabled.
 
 == Changelog ==
+
+=== ratpoints-2.1.3.p3 (Leif Leonhardy, March 17th 2012) ===
+ * #12682: Patch `Makefile` such that the `CC` (and `INSTALL_DIR`) environment
+   variable(s) override(s) the setting in the Makefile.
+ * Some clean-up; use `$MAKE` instead of `make`, also install the library
+   with `make` (i.e., `$MAKE`) rather than "by hand".
+ * TODO:
+   - The Makefile has a `test` target; don't know whether we should
+     run some tests, and whether it's worth an `spkg-check` script (for
+     which we'd presumably have to duplicate the whole `CCFLAGS*` setup).
 
 === ratpoints-2.1.3.p2 (Jeroen Demeyer, 13 February 2012) ===
  * #12368: Add compiler flag -fnested-functions if and only if it is

--- a/build/pkgs/ratpoints/patches/Makefile.patch
+++ b/build/pkgs/ratpoints/patches/Makefile.patch
@@ -1,0 +1,37 @@
+--- src/Makefile	2009-10-01 01:08:54.000000000 +0200
++++ patches/Makefile	2012-03-17 13:57:33.026315142 +0100
+@@ -21,11 +21,11 @@
+ #
+ #    Michael Stoll, September 21, 2009
+ 
+-CC = gcc
++CC ?= gcc
+ RM = rm -f
+ INSTALL = cp
+ 
+-INSTALL_DIR = /usr/local
++INSTALL_DIR ?= /usr/local
+ 
+ DISTFILES = Makefile ratpoints.h rp-private.h primes.h \
+             gen_find_points_h.c gen_init_sieve_h.c \
+@@ -47,14 +47,14 @@
+ 	diff -q testbase rptest.out
+ 
+ install-bin: ratpoints
+-	${INSTALL} ratpoints ${INSTALL_DIR}/bin/
+-	chmod 755 ${INSTALL_DIR}/bin/ratpoints
++	${INSTALL} ratpoints "${INSTALL_DIR}/bin/"
++	chmod 755 "${INSTALL_DIR}/bin/ratpoints"
+ 
+ install-lib: ratpoints.h libratpoints.a
+-	${INSTALL} ratpoints.h ${INSTALL_DIR}/include/
+-	chmod 644 ${INSTALL_DIR}/include/ratpoints.h
+-	${INSTALL} libratpoints.a ${INSTALL_DIR}/lib/
+-	chmod 644 ${INSTALL_DIR}/lib/libratpoints.a
++	${INSTALL} ratpoints.h "${INSTALL_DIR}/include/"
++	chmod 644 "${INSTALL_DIR}/include/ratpoints.h"
++	${INSTALL} libratpoints.a "${INSTALL_DIR}/lib/"
++	chmod 644 "${INSTALL_DIR}/lib/libratpoints.a"
+ 
+ install: install-bin install-lib
+ 

--- a/build/pkgs/ratpoints/spkg-install
+++ b/build/pkgs/ratpoints/spkg-install
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 
-if [ "$SAGE_LOCAL" = "" ]; then
-   echo "SAGE_LOCAL undefined ... exiting";
-   echo "Maybe run 'sage -sh'?"
-   exit 1
+if [[ -z $SAGE_LOCAL ]]; then
+    echo >&2 "Error: SAGE_LOCAL undefined - exiting..."
+    echo >&2 "Maybe run 'sage -sh'?"
+    exit 1
 fi
-
-cd src
 
 PRIME_SIZE=7
 
@@ -14,11 +12,12 @@ CCFLAGS_NO_SSE="-I$SAGE_LOCAL/include -Wall -O2 -fPIC -DRATPOINTS_MAX_BITS_IN_PR
 CCFLAGS2="-L$SAGE_LOCAL/lib -lgmp -lm"
 CCFLAGS3="-L. -lratpoints"
 
-if [ `uname` = "Darwin" ]; then
+if [[ "$UNAME" = "Darwin" ]]; then
     CCFLAGS1="$CCFLAGS_NO_SSE"
-    echo "Building without SSE2 instructions (OS X)."
+    echo "Building without SSE2 instructions (MacOS X)."
 else
     CCFLAGS1="$CCFLAGS_NO_SSE -DUSE_SSE"
+    echo "Attempting to build ratpoints making use of SSE2 instructions."
 fi
 
 # Copy CFLAGS set externally to CCFLAGS.
@@ -26,13 +25,13 @@ fi
 CCFLAGS="`testcflags.sh -fnested-functions` $CFLAGS"
 
 # When CFLAG64 is not set, set it to the default -m64
-if [ -z $CFLAG64 ]; then
+if [[ -z $CFLAG64 ]]; then
     CFLAG64=-m64
 fi
 
-if [ "x$SAGE64" = xyes ]; then
-    echo "Building with extra 64-bit flags for OS X and Open Solaris"
-    CCFLAGS="$CFLAG64 $CCFLAGS"
+if [[ "$SAGE64" = yes ]]; then
+    echo "Building with extra 64-bit flags for MacOS X and Open Solaris."
+    CCFLAGS="$CCFLAGS $CFLAG64"
 fi
 
 export CCFLAGS1
@@ -40,23 +39,57 @@ export CCFLAGS2
 export CCFLAGS3
 export CCFLAGS
 
-# PLEASE, don't break this again by deleting "libratpoints.a".  See trac 8267.
-make libratpoints.a
+cd src/
 
-if [ $? -ne 0 ]; then
-    if [ "$UNAME" != "Darwin" ]; then
-        echo "Build failed. Trying without SSE2 instructions."
-        CCFLAGS1="$CCFLAGS_NO_SSE"; export CCFLAGS1
-        make libratpoints.a
-    else
-        echo "Error building ratpoints"
+###########################
+# Apply patches (if any): #
+###########################
+
+echo "Applying patches to upstream source..."
+for patch in ../patches/*.patch; do
+    patch -p1 <"$patch"
+    if [[ $? -ne 0 ]]; then
+        echo >&2 "Error applying '$patch'."
         exit 1
     fi
-    if [ $? -ne 0 ]; then
-        echo "Error building ratpoints"
+done
+
+#############################
+# Build (just) the library: #
+#############################
+
+# PLEASE, don't break this again by deleting "libratpoints.a".  See trac 8267.
+$MAKE libratpoints.a
+
+if [[ $? -ne 0 ]]; then
+    if [[ "$UNAME" = "Darwin" ]]; then
+        echo >&2 "Error building ratpoints."
+        exit 1
+    fi
+    echo "Build failed. Trying without SSE2 instructions."
+    CCFLAGS1="$CCFLAGS_NO_SSE"
+    $MAKE libratpoints.a
+    if [[ $? -ne 0 ]]; then
+        echo >&2 "Error building ratpoints."
         exit 1
     fi
 fi
 
-cp libratpoints.a "$SAGE_LOCAL"/lib/
-cp ratpoints.h "$SAGE_LOCAL"/include/
+##############################################
+# Install (just) the library and its header: #
+##############################################
+
+# cp libratpoints.a "$SAGE_LOCAL"/lib/
+# cp ratpoints.h "$SAGE_LOCAL"/include/
+
+# The following requires that the Makefile got patched;
+# otherwise one could pass 'INSTALL_DIR=...' on the 'make'
+# command line:
+export INSTALL_DIR="$SAGE_LOCAL"
+$MAKE install-lib
+if [[ $? -ne 0 ]]; then
+    echo >&2 "Error installing ratpoints library."
+    exit 1
+fi
+
+# TODO: How about 'make test'? Do we need an spkg-check script?


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12682">trac #12682</a>.

Diff between the vanilla Makefile and the (patched) one of the p3.  For reference and (better) review only.

Reported by: leif

Component: packages

CC: rlm,, jdemeyer,, rohana,, mjo

Report Upstream: N/A

Authors: Leif Leonhardy

Dependencies: 

Work issues: 

Reviewers: R. Andrew Ohana

Merged in: sage-5.0.beta9

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12682/ratpoints-2.1.3.p2-p3.diff">ratpoints-2.1.3.p2-p3.diff: Diff between the p2 and my p3. For reference / review only.</a> by leif at 20120317T14:17:00</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12682/ratpoints-2.1.3-Makefile.vanilla-p3.diff">ratpoints-2.1.3-Makefile.vanilla-p3.diff: Diff between the vanilla Makefile and the (patched) one of the p3.  For reference and (better) review only.</a> by leif at 20120317T14:31:45</li></ol>
