### PR TITLE
Fix hardcoded 'g++' in Lcalc 1.23 [p9]

### DIFF
--- a/build/pkgs/lcalc/SPKG.txt
+++ b/build/pkgs/lcalc/SPKG.txt
@@ -46,10 +46,13 @@ http://code.google.com/p/l-calc/
  * We (and apparently also upstream) currently don't build Lcalc's tests
    (see Makefile), hence there's no spkg-check.
    This might change in newer upstream versions.
- * TODO / FIXME:
-   The (upstream) Makefile uses $(CC) to compile C++ (also using $(CCFLAGS)),
+ * The original Makefile uses $(CC) to compile C++ (also using $(CCFLAGS)),
    which it defines to 'g++', and hardcodes 'g++' when linking the shared
    library. (It should use $(CXX) instead, which might *default* to 'g++'.)
+   We now (lcalc-1.23.p10) patch the Makefile also to use $(CXX) for compiling
+   and linking C++; $(CXX) now *defaults* to 'g++', and $(CC) to 'gcc', but
+   both can be overridden by simply setting their respective environment
+   variables.  (Same for $(INSTALL_DIR) btw.)
 
 == Patches ==
 
@@ -61,7 +64,13 @@ http://code.google.com/p/l-calc/
    - put CXXFLAGS into Lcalc's "CCFLAGS" used for compiling C++,
    - remove some stuff involving LDFLAGS1 and LDFLAGS2, setting just LDFLAGS,
    - use $(MAKE) instead of 'make' in the crude build receipts,
-   - use CXXFLAG64 when linking the shared library.
+   - use CXXFLAG64 when linking the shared library,
+   - now use $(CXX) for compiling and linking C++, which *defaults* to 'g++',
+     but can be overridden by setting the environment variable of the same
+     name.  ($(CC) now *defaults* to 'gcc', although currently not really
+     used as far as I can see.)
+   - $(INSTALL_DIR) can now be overridden by simply setting the environment
+     variable of the same name.
  * Lcommon.h.patch:
    Uncomment the definition of lcalc_to_double(const long double& x).
    (Necessary for GCC >= 4.6.0, cf. #10892.)
@@ -82,6 +91,14 @@ http://code.google.com/p/l-calc/
    This should get reported upstream.
 
 == Changelog ==
+
+=== lcalc-1.23.p10 (Leif Leonhardy, March 17th 2012) ===
+ * #12681: Fix hard-coded 'g++'.
+   The (patched) Makefile now uses $(CXX) (which *defaults* to 'g++')
+   for compiling and linking C++, $(CC) (which *defaults* to 'gcc') for
+   compiling C, although the latter is [currently] hardly used.
+   See also "Special Update/Build Instructions" above. (We could now also
+   set `INSTALL_DIR` and use 'make install'...)
 
 === lcalc-1.23.p9 (Jeroen Demeyer, Leif Leonhardy, 6 October 2011) ===
  * Trac #11321: Add a patch for PARI-2.4.4 (use allocatemem() instead of

--- a/build/pkgs/lcalc/patches/Makefile.patch
+++ b/build/pkgs/lcalc/patches/Makefile.patch
@@ -1,15 +1,32 @@
---- src/src/Makefile	2010-01-31 16:16:45.000000000 +0100
-+++ src/src/Makefile	2010-09-19 18:24:23.059332566 +0200
+--- src/src/Makefile	2009-07-14 20:23:17.000000000 +0200
++++ src/src/Makefile	2012-03-17 08:16:53.346311160 +0100
 @@ -13,7 +13,7 @@
  # elliptic curve routines. Doing so disables the -e option.
  # g++ with -DINCLUDE_PARI sends a #define INCLUDE_PARI to the preprocessor.
-
+ 
 -#PARI_DEFINE = -DINCLUDE_PARI
 +PARI_DEFINE = -DINCLUDE_PARI
  #PREPROCESSOR_DEFINE = -DUSE_LONG_DOUBLE
-
+ 
  #OPENMP_FLAG = -fopenmp
-@@ -58,9 +58,7 @@
+@@ -29,7 +29,15 @@
+ 
+ OS_NAME := $(shell uname)
+ 
+-CC = g++
++#CC = g++
++# Note: I've also changed various rules to use $CXX instead of $CC,
++# since we mostly compile C++, not C, and $CC is by convention
++# used for the *C* compiler.
++# I've kept the [name] CCFLAGS though, which we add $CXXFLAGS to.
++# -leif (03/2012)
++CC ?= gcc
++CXX ?= g++
++
+ #cc = /home/mrubinst/local/bin/gcc
+ #CC = /home/mrubinst/local/bin/g++
+ #LD = /home/mrubinst/local/bin/g++
+@@ -58,9 +66,7 @@
     #MACHINE_SPECIFIC_FLAGS = -mpowerpc -mpowerpc64 -m64
  endif
  
@@ -20,7 +37,7 @@
  
  #warning- O2 doesn't help with -DUSE_LONG_DOUBLE on mac, and actually seems to hurt, making runtime longer
  #by a factor of 1.5
-@@ -68,12 +66,12 @@
+@@ -68,12 +74,12 @@
  
  ifeq ($(PARI_DEFINE),-DINCLUDE_PARI)
      #location of pari.h.
@@ -35,7 +52,7 @@
  else
      #supplied as a dummy so as to avoid more ifeq's below
      LOCATION_PARI_H = .
-@@ -88,26 +86,12 @@
+@@ -88,26 +94,12 @@
  #For Mac os x we omit shared library options
  
  ifeq ($(OS_NAME),Darwin)
@@ -63,7 +80,16 @@
  
  
  
-@@ -140,12 +124,12 @@
+@@ -129,7 +121,7 @@
+ #become clear which libraries the computer can find.
+ 
+ 
+-INSTALL_DIR= /usr/local
++INSTALL_DIR ?= /usr/local
+ 
+ #object files for the libLfunction library
+ OBJ_L = Lglobals.o Lgamma.o Lriemannsiegel.o Lriemannsiegel_blfi.o Ldokchitser.o
+@@ -140,34 +132,37 @@
  OBJECTS = $(OBJ3)
  
  all:
@@ -82,12 +108,66 @@
  
  print_vars:
  	@echo OS_NAME = $(OS_NAME)
-@@ -262,7 +246,7 @@
+ 
+ lcalc: $(OBJECTS)
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) $(OBJECTS) $(LDFLAGS) -o lcalc $(GMP_FLAGS)
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) $(OBJECTS) $(LDFLAGS) -o lcalc $(GMP_FLAGS)
+ 
+ examples:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/example.cc libLfunction.so -o example_programs/example $(GMP_FLAGS)
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) example_programs/example.cc libLfunction.so -o example_programs/example $(GMP_FLAGS)
+ 
+ 
+ proc:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/proc.cc libLfunction.so -o example_programs/proc $(GMP_FLAGS)
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) example_programs/proc.cc libLfunction.so -o example_programs/proc $(GMP_FLAGS)
+ 
+ test:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) example_programs/test.cc libLfunction.so -o example_programs/test $(GMP_FLAGS)
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) example_programs/test.cc libLfunction.so -o example_programs/test $(GMP_FLAGS)
+ 
+ find_L:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) find_L_functions/find_L_functions.cc libLfunction.so -o find_L_functions/find_L $(GMP_FLAGS)
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) find_L_functions/find_L_functions.cc libLfunction.so -o find_L_functions/find_L $(GMP_FLAGS)
++
+ 
+ .cc.o:
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) -c $<
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -c $<
++
++# Warning: We (Sage) add $CXXFLAGS to CCFLAGS above.
+ .c.o:
+ 	$(CC) $(CCFLAGS) $(INCLUDEFILES) -c $<
+ 
+@@ -227,7 +222,7 @@
+ Lcommandline_elliptic.o: ../include/Lvalue.h ../include/Lfind_zeros.h
+ Lcommandline_elliptic.o: ../include/Lcommandline_numbertheory.h
+ Lcommandline_elliptic.o: ../include/Lcommandline_globals.h
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_elliptic.cc
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_elliptic.cc
+ 
+ Lcommandline_twist.o: ../include/Lcommandline_twist.h ../include/L.h
+ Lcommandline_twist.o: ../include/Lglobals.h ../include/Lcommon.h ../include/Lcomplex.h ../include/Lnumeric.h ../include/Lint_complex.h
+@@ -239,7 +234,7 @@
+ Lcommandline_twist.o: ../include/Lcommandline_numbertheory.h
+ Lcommandline_twist.o: ../include/Lcommandline_globals.h
+ Lcommandline_twist.o: ../include/Lcommandline_elliptic.h
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_twist.cc
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline_twist.cc
+ 
+ cmdline.o: ../include/cmdline.h ../include/getopt.h
+ #$(CC) $(CCFLAGS) $(INCLUDEFILES) -DHAVE_LONG_LONG -c cmdline.c
+@@ -258,11 +253,11 @@
+ Lcommandline.o: ../include/Lcommandline_elliptic.h
+ Lcommandline.o: ../include/Lcommandline_twist.h
+ Lcommandline.o: ../include/Lcommandline_values_zeros.h
+-	$(CC) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline.cc
++	$(CXX) $(CCFLAGS) $(INCLUDEFILES) -I$(LOCATION_PARI_H) $(PARI_DEFINE) -c Lcommandline.cc
  
  
  libLfunction.so: $(OBJ_L)
 -	g++ -$(DYN_OPTION)  -o libLfunction.so $(OBJ_L)
-+	g++ -$(DYN_OPTION) $(CXXFLAG64) -o libLfunction.so $(OBJ_L)
++	$(CXX) -$(DYN_OPTION) $(CXXFLAG64) -o libLfunction.so $(OBJ_L)
  
  clean:
  	rm -f *.o lcalc libLfunction.so example_programs/example


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12681">trac #12681</a>.

Diff between the (patched) Makefile of the p9 and the p10.  For reference / review only.

Reported by: leif

Component: packages

CC: rishi,, jdemeyer,, rohana,, mjo

Report Upstream: N/A

Authors: Leif Leonhardy

Dependencies: 

Work issues: 

Reviewers: R. Andrew Ohana

Merged in: sage-5.0.beta9

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12681/lcalc-1.23.p9-p10.diff">lcalc-1.23.p9-p10.diff: Diff between the p9 and my p10. For reference / review only.</a> by leif at 20120317T12:19:05</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12681/Lcalc-1.23-Makefile.p9-p10.diff">Lcalc-1.23-Makefile.p9-p10.diff: Diff between the (patched) Makefile of the p9 and the p10.  For reference / review only.</a> by leif at 20120317T12:20:32</li></ol>
