### PR TITLE
Fix scoping / name look-up issue in PolyBoRi 0.8.0 and support flags from the environment

### DIFF
--- a/build/pkgs/polybori/patches/base_lookup.patch
+++ b/build/pkgs/polybori/patches/base_lookup.patch
@@ -1,0 +1,31 @@
+# HG changeset patch
+# User Alexander Dreyer <adreyer@gmx.de>
+# Date 1332364717 -3600
+# Node ID 43b3931ceed7b57c4c5385442de6ff45bd0f477c
+# Parent  617ce1a715329d16e5ebde0bfdde9c4d09072451
+FIX explict name lookups (in template base)
+
+diff -r 617ce1a715329d16e5ebde0bfdde9c4d09072451 -r 43b3931ceed7b57c4c5385442de6ff45bd0f477c libpolybori/include/polybori/iterators/CTermStack.h
+--- a/libpolybori/include/polybori/iterators/CTermStack.h	Mon Mar 19 22:53:46 2012 +0100
++++ b/libpolybori/include/polybori/iterators/CTermStack.h	Wed Mar 21 22:18:37 2012 +0100
+@@ -853,7 +853,7 @@
+     PBORI_ASSERT(m_zero.isValid());
+     PBORI_ASSERT(m_zero.isEmpty());
+ 
+-    push(m_zero);
++    base::push(m_zero);
+   }
+ 
+ private:
+diff -r 617ce1a715329d16e5ebde0bfdde9c4d09072451 -r 43b3931ceed7b57c4c5385442de6ff45bd0f477c libpolybori/include/polybori/orderings/CBlockOrderingFacade.h
+--- a/libpolybori/include/polybori/orderings/CBlockOrderingFacade.h	Mon Mar 19 22:53:46 2012 +0100
++++ b/libpolybori/include/polybori/orderings/CBlockOrderingFacade.h	Wed Mar 21 22:18:37 2012 +0100
+@@ -91,7 +91,7 @@
+     CacheManager<order_lead_tag> cache_mgr(poly.ring());
+     typename base_type::descending_property descending;
+ 
+-    return monom(  dd_block_degree_lead(cache_mgr, blockDegCache, 
++    return base_type::monom( dd_block_degree_lead(cache_mgr, blockDegCache, 
+                                         poly.navigation(), m_indices.begin(),
+                                         set_type(poly.ring()), descending) );
+   }

--- a/build/pkgs/polybori/patches/custom.py
+++ b/build/pkgs/polybori/patches/custom.py
@@ -2,9 +2,20 @@ import os
 import sys
 
 # FIXME: Do we really want to *overwrite* the flags (e.g. if set by the user)?
+# Note: there will be better ways in PolyBoRi 0.8.1
 CCFLAGS=["-O3 -Wno-long-long -Wreturn-type -g -fPIC"]
 #CXXFLAGS=CCFLAGS+["-ftemplate-depth-100 -g -fPIC"]
 CXXFLAGS=CCFLAGS+["-ftemplate-depth-100"]
+CFLAGS=["-std=c99"]
+
+if 'CFLAGS' in os.environ:
+  CFLAGS += os.environ['CFLAGS'].split(' ')
+
+if 'CXXFLAGS' in os.environ:
+  CXXFLAGS += os.environ['CXXFLAGS'].split(' ')
+
+if 'CPPFLAGS' in os.environ:
+  CCFLAGS += os.environ['CPPFLAGS'].split(' ')
 
 GD_LIBS+=["png12","z"]
 

--- a/build/pkgs/polybori/spkg-install
+++ b/build/pkgs/polybori/spkg-install
@@ -10,7 +10,7 @@ PBDIR=polybori-0.8.0
 WORKDIR=${PWD}/src
 SCONS=scons
 
-patch()
+prepare()
 {
     if [ $UNAME = "CYGWIN" ]; then
         export PROGSUFFIX=.exe
@@ -19,6 +19,10 @@ patch()
     cp patches/custom.py             src/${PBDIR}
     cp patches/SConstruct            src/${PBDIR}/SConstruct
     cp patches/PyPolyBoRi.py         src/${PBDIR}/pyroot/polybori
+
+    cd ${WORKDIR}/${PBDIR}
+    patch -p1 < ../../patches/base_lookup.patch
+    cd ${WORKDIR}
 }
 
 build_polybori()
@@ -57,9 +61,7 @@ clean_polybori()
     rm -rf ${SAGE_LOCAL}/include/cudd
 }
 
-patch
-
-cd src
+prepare
 
 echo "Starting build..."
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12750">trac #12750</a>.

The following was found out here:
http://groups.google.com/group/sage-release/browse_thread/thread/e2a87c73dc1625f2

```
* PolyBoRi fails to build due to stricter (C++11) scoping / name look-up rules.
    Unfortunately PolyBoRi doesn't honor CXXFLAGS, so I had to use CXX="g++-4.7.0 -fpermissive" to make the spkg build. 
```

The scoping issue should be fixed here:
https://bitbucket.org/brickenstein/polybori/changeset/43b3931ceed7/raw/

Also, we should support CXXFLAGS and CFLAGS (ANd CPPFLAGS?) in the spkg.

=== Current spkg ===
- **Install** http://boxen.math.washington.edu/home/dreyer/spkg/polybori-0.8.0.p2.spkg

Reported by: AlexanderDreyer

Component: algebra

CC: leif,, PolyBoRi,, malb,, burcin

Report Upstream: Fixed upstream, in a later stable release.

Authors: Alexander Dreyer

Dependencies: 

Work issues: 

Reviewers: Leif Leonhardy

Merged in: sage-5.0.beta12

Attachments: <ol></ol>
