### PR TITLE
Don't "import site" in sympy's installer

### DIFF
--- a/build/pkgs/sympy/SPKG.txt
+++ b/build/pkgs/sympy/SPKG.txt
@@ -28,6 +28,11 @@ sympy mailinglist: http://groups.google.com/group/sympy
 
 == Changelog ==
 
+=== sympy-0.7.1.p0 (Francois Bissey, 22 February 2012) ===
+ * Trac #12563: add -S option to python to prevent sympy's installer
+   from importing sage.
+ * Clean up spkg-install.
+
 === sympy-0.7.1 (Francois Bissey, Sep 16, 2011) ===
  * trac 11560: update to new upstream release
  * clean old obsolete script.

--- a/build/pkgs/sympy/spkg-install
+++ b/build/pkgs/sympy/spkg-install
@@ -1,36 +1,35 @@
 #!/usr/bin/env bash
 
 if [ "$SAGE_LOCAL" = "" ]; then
-   echo "SAGE_LOCAL undefined ... exiting";
-   echo "Maybe run 'sage -sh'?"
-   exit 1
+    echo >&2 "SAGE_LOCAL undefined ... exiting"
+    echo >&2 "Maybe run 'sage -sh'?"
+    exit 1
 fi
 
 cd src/
 
-# Because sympy imports itself in setup.py we need to set PYTHONPATH
-# to avoid loading the currently installed version.
+# sympy imports itself, and therefore it indirectly imports sage in
+# setup.py.  We need to set PYTHONPATH=. and use the -S option to avoid
+# importing the currently installed version of sympy, and to avoid
+# importing sage.
+export PYTHONPATH="."
 echo "building sympy"
-PYTHONPATH="." python setup.py build
+python -S setup.py build
 
 if [ $? -ne 0 ]; then
-   echo "Error building sympy"
-   exit 1
-fi
-
-# Removing old sympy so that there are no leftover undesirable files,
-# we do this in any python2 install.
-if [ "$SAGE_ROOT" = "" ]; then
-    echo "Please set the SAGE_ROOT variable"
+    echo >&2 "Error building sympy"
     exit 1
 fi
-echo "Deleting $SAGE_ROOT/local/lib/python2.x/site-packages/sympy*"
-rm -rf $SAGE_ROOT/local/lib/python2.*/site-packages/sympy*
 
-if [ $? -ne 0 ]; then
-   echo "Error removing old sympy"
-   exit 1
-fi
+# It is very important that we have SAGE_LOCAL set, otherwise this
+# might potentially delete stuff in /lib
+echo "Deleting $SAGE_LOCAL/lib/python2.*/site-packages/sympy*"
+rm -rf $SAGE_LOCAL/lib/python2.*/site-packages/sympy*
 
 echo "installing sympy"
-PYTHONPATH="." python setup.py install
+python -S setup.py install
+
+if [ $? -ne 0 ]; then
+    echo >&2 "Error installing sympy"
+    exit 1
+fi


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12563">trac #12563</a>.

Diff for the sympy spkg, for review only

Reported by: jdemeyer

Component: packages

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: William Stein

Merged in: sage-5.0.beta6

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/12563/sympy-0.7.1.p0.diff">sympy-0.7.1.p0.diff: Diff for the sympy spkg, for review only</a> by jdemeyer at 20120223T17:38:06</li></ol>
