### PR TITLE
$SAGE_LOCAL/lib and lib64

### DIFF
--- a/build/pkgs/freetype/SPKG.txt
+++ b/build/pkgs/freetype/SPKG.txt
@@ -3,6 +3,9 @@ MAINTAINER:
 
 == Releases ==
 
+=== freetype-2.3.5.p4 (Simon King, December 11th 2011) ===
+ * #12131: Use --libdir, to make the package work on openSUSE
+
 === freetype-2.3.5.p3 (Mitesh Patel, October 21st 2010) ===
  * #9221, #9896: Increase the patch level to force reinstallation when
     upgrading to Sage 4.6.  This works around a problem with moved

--- a/build/pkgs/freetype/spkg-install
+++ b/build/pkgs/freetype/spkg-install
@@ -13,7 +13,7 @@ fi
 
 cd src
 
-GNUMAKE=${MAKE} ./configure --prefix="$SAGE_LOCAL"
+GNUMAKE=${MAKE} ./configure --prefix="$SAGE_LOCAL" --libdir="$SAGE_LOCAL/lib"
 
 if [ $? -ne 0 ]; then
     exit 1;


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/12131">trac #12131</a>.

Some distributions set up autotools to install libraries into `%{prefix}/lib64`, which breaks Sage's assumption that libraries are installed in `$SAGE_LOCAL/lib`. In particular, !OpenSuse64 according to this thread https://groups.google.com/d/topic/sage-devel/LS-u8E77NJQ/discussion

It seems like we have two options:
- Always call `./configure --libdir='${prefix}/lib'` to explicitly specify the library directory, or
- Set up a symlink `$SAGE_LOCAL/lib64` -> `$SAGE_LOCAL/lib`.

The symlink is the lazy thing to do but will probably break again with the next architectural change. Fixing the configure call seems the right thing to do but will need some work to patch up all spkgs.

Updated spkgs:
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/boehm_gc-7.2.alpha6.p2.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/cddlib-094f.p9.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/ecl-11.1.2.cvs20111120.p1.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/ecm-6.3.p3.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/freetype-2.3.5.p4.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/gd-2.0.35.p6.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/givaro-3.2.13.rc1.p3.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/glpk-4.44.p0.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/gnutls-2.2.1.p6.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/gsl-1.15.p0.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/iml-1.0.1.p14.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/libfplll-3.0.12.p2.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/libgcrypt-1.4.4.p4.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/libgpg_error-1.6.p4.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/libm4ri-20111004.p0.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/libm4rie-20111004.p0.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/libpng-1.2.35.p4.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/linbox-1.1.6.p6.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/maxima-5.23.2.p3.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/mpir-2.1.3.p9.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/mpfi-1.3.4-cvs20071125.p9.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/mpfr-2.4.2.p0.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/opencdk-0.6.6.p6.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/ppl-0.11.2.p0.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/pynac-0.2.3.p0.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/python-2.6.4.p13.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/r-2.14.0.p1.spkg
- http://www.stp.dias.ie/~vbraun/Sage/spkg/readline-6.2.p2.spkg
- http://sage.math.washington.edu/home/SimonKing/SAGE/SUSE/sqlite-3.7.5.p0.spkg

Note that I based the r-package on the version from <a href="http://trac.sagemath.org/sage_trac/ticket/12057">trac #12057</a> (which has already been fixed); note that <a href="http://trac.sagemath.org/sage_trac/ticket/12057">trac #12057</a> also contains a patch that needs to be applied.

Similarly, the mpir package is based on the version from <a href="http://trac.sagemath.org/sage_trac/ticket/12139">trac #12139</a>.

Reported by: vbraun

Component: build

CC: SimonKing,, malb

Report Upstream: N/A

Authors: Volker Braun, Simon King

Dependencies: <a href="http://trac.sagemath.org/sage_trac/ticket/12057 #12139">trac #12057 #12139</a>

Work issues: 

Reviewers: Simon King, Volker Braun

Merged in: sage-4.8.alpha5

Attachments: <ol></ol>
