### PR TITLE
docutils files not world-readable

### DIFF
--- a/build/pkgs/docutils/SPKG.txt
+++ b/build/pkgs/docutils/SPKG.txt
@@ -31,6 +31,9 @@ None
 
 == Changelog ==
 
+=== docutils-0.7.p0 (Jeroen Demeyer, 8 August 2011) ===
+ * Trac #11660: Change permissions of files inside /src to world-readable
+
 === docutils-0.7 (Pablo De Napoli, 24 October 2010) ===
  * Upgrade to latest upstream stable release (trac #10166)
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/11660">trac #11660</a>.

The new docutils spkg from <a href="http://trac.sagemath.org/sage_trac/ticket/10166">trac #10166</a> has its `src` directory not world-readable which causes trouble when running Sage as a different user from the user which compiled Sage.  For example, the following fails from the notebook:

```
sage: EllipticCurve?
IOError: [Errno 13] Permission denied: '/usr/local/sage/sage-4.7.1.rc0/local/lib/python2.6/site-packages/docutils/writers/html4css1/html4css1.css'
```

This problem is not upstream, it was introduced in Sage.

New spkg simply changing the permission of the files inside the `src` directory of the spkg: [http://boxen.math.washington.edu/home/jdemeyer/spkg/docutils-0.7.p0.spkg]

Reported by: jdemeyer

Component: packages

CC: 

Report Upstream: N/A

Authors: Jeroen Demeyer

Dependencies: 

Work issues: 

Reviewers: Leif Leonhardy

Merged in: sage-4.7.1.rc2

Attachments: <ol></ol>
