### PR TITLE
update matplotlib to 1.0.0 and clean out the patches

### DIFF
--- a/build/pkgs/freetype/SPKG.txt
+++ b/build/pkgs/freetype/SPKG.txt
@@ -3,6 +3,11 @@ MAINTAINER:
 
 == Releases ==
 
+=== freetype-2.3.5.p3 (Mitesh Patel, October 21st 2010) ===
+ * #9221, #9896: Increase the patch level to force reinstallation when
+    upgrading to Sage 4.6.  This works around a problem with moved
+    Sage installations.
+
 === freetype-2.3.5.p2 (David Kirkby, January 2nd 2010) ===
  * #7138 Ensure -m64 gets added on all platforms, not just OS X
    A better fix will be to remove all the hard-coded -m64 junk


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/9221">trac #9221</a>.

Reported by: jason

Component: graphics

CC: drkirkby,, kcrisman

Report Upstream: Fixed upstream, but not in a stable release.

Authors: Jason Grout

Dependencies: 

Work issues: 

Reviewers: David Kirkby, Karl-Dieter Crisman

Merged in: sage-4.6.alpha3

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9221/trac-9221-matplotlib-update.patch">trac-9221-matplotlib-update.patch: </a> by jason at 20100814T15:57:06</li></ol>
