### PR TITLE
Stealth core dump from testing sage/interfaces/genus2reduction.py

### DIFF
--- a/build/pkgs/genus2reduction/SPKG.txt
+++ b/build/pkgs/genus2reduction/SPKG.txt
@@ -9,6 +9,9 @@ the place to fix it.
 
 == Releases ==
 
+=== genus2reduction-0.3.p8 (Jeroen Demeyer, August 14, 2010) ===
+ * #9738: don't catch signals and exit cleanly upon EOF
+
 === genus2reduction-0.3.p7 (Jeroen Demeyer, July 24, 2010) ===
  * upgrade to PARI 2.4.3
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/9738">trac #9738</a>.

Alternative patch to fix the issue

Reported by: mpatel

Component: doctest

CC: robertwb,, was,, jdemeyer

Report Upstream: N/A

Authors: 

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9738/genus2reduction.c.diff">genus2reduction.c.diff: Quit on `quit`.  Diff of `genus2reduction.c` from g2r 0.3.p6.</a> by mpatel at 20100813T00:40:49</li><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/9738/9738_genus2reduction_init_opts.patch">9738_genus2reduction_init_opts.patch: Alternative patch to fix the issue</a> by jdemeyer at 20100813T22:49:53</li></ol>
