### PR TITLE
boehm_gc fails to build on Cygwin

### DIFF
--- a/build/pkgs/boehm_gc/SPKG.txt
+++ b/build/pkgs/boehm_gc/SPKG.txt
@@ -27,6 +27,9 @@ None. Sources in src are vanilla.
 
 == Changelog ==
 
+=== boehm_gc-7.1.p4 (Mike Hansen, February 15th, 2010) ===
+ * #7336: Make boehm_gc work on Cygwin by disabling THREADDLLIBS.
+
 === boehm_gc-7.1.p3 (Jaap Spies, Jan 25th, 2010) ===
  * made SAGE64 also work for Open Solaris 64 bit
 

--- a/build/pkgs/boehm_gc/spkg-install
+++ b/build/pkgs/boehm_gc/spkg-install
@@ -21,6 +21,11 @@ if [ "$SAGE64" = "yes" ]; then
    LDFLAGS="-m64"; export LDFLAGS
 fi
 
+# See ticket #7336
+if [ $UNAME = "CYGWIN" ]; then
+    THREADDLLIBS = ""; export THREADDLLIBS
+fi
+
 cd src
 ./configure --prefix=$SAGE_LOCAL --enable-large-config
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/7336">trac #7336</a>.

It fails with 

```
  /bin/sh ./libtool --tag=CC --mode=link gcc -fexceptions -I libatomic_ops/src -g -O2   -o libcord.la -rpath /home/mhansen/sage-4.2/local/lib -version-info 1:3:0 -no-undefined cord/cordbscs.lo cord/cordprnt.lo cord/cordtest.lo cord/cordxtra.lo ./libgc.la 

  *** Warning: This system can not link to static lib archive ./libgc.la.
  *** I have the capability to make that library automatically link in when
  *** you link to this library.  But I can only do this if you have a
  *** shared version of the library, which you do not appear to have.
  rm -fr  .libs/libcord.dll.a
  gcc -shared  cord/.libs/cordbscs.o cord/.libs/cordprnt.o cord/.libs/cordtest.o cord/.libs/cordxtra.o   -o .libs/cygcord-1.dll -Wl,--enable-auto-image-base -Xlinker --out-implib -Xlinker .libs/libcord.dll.a
  Creating library file: .libs/libcord.dll.a
  cord/.libs/cordbscs.o: In function `CORD_from_fn':
  /home/mhansen/sage-4.2/spkg/build/boehm_gc-7.1.p2/src/cord/cordbscs.c:288: undefined reference to `_GC_malloc_atomic'
  /home/mhansen/sage-4.2/spkg/build/boehm_gc-7.1.p2/src/cord/cordbscs.c:298: undefined reference to `_GC_malloc'
  cord/.libs/cordbscs.o: In function `CORD_substr_closure':
  /home/mhansen/sage-4.2/spkg/build/boehm_gc-7.1.p2/src/cord/cordbscs.c:344: undefined reference to `_GC_malloc'
```

This can be fixed by setting THREADDLLIBS to be empty.

I'll post an updated spkg here shortly.

Reported by: mhansen

Component: cygwin

CC: was

Report Upstream: N/A

Authors: Mike Hansen

Dependencies: 

Work issues: 

Reviewers: Minh Van Nguyen

Merged in: sage-4.3.3.alpha1

Attachments: <ol></ol>
