### PR TITLE
New boehm-gc-7.1.p3.spkg works with Open Solaris x64 as 64-bit

### DIFF
--- a/build/pkgs/boehm_gc/SPKG.txt
+++ b/build/pkgs/boehm_gc/SPKG.txt
@@ -27,6 +27,9 @@ None. Sources in src are vanilla.
 
 == Changelog ==
 
+=== boehm_gc-7.1.p3 (Jaap Spies, Jan 25th, 2010) ===
+ * made SAGE64 also work for Open Solaris 64 bit
+
 === boehm_gc-7.1.p2 (William Stein, September 20th, 2009) ===
  * add OS X Snow Leopoard support
 

--- a/build/pkgs/boehm_gc/spkg-install
+++ b/build/pkgs/boehm_gc/spkg-install
@@ -15,8 +15,8 @@ if [ $UNAME = "Darwin" ]; then
    $CP patches/mach_dep.c src/
 fi
 
-if [ $UNAME = "Darwin" -a "$SAGE64" = "yes" ]; then
-   echo "64 bit MacIntel"
+if [ "$SAGE64" = "yes" ]; then
+   echo "64 bit build"
    CFLAGS="-O2 -g -fPIC -m64 "; export CFLAGS
    LDFLAGS="-m64"; export LDFLAGS
 fi


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/8057">trac #8057</a>.

Reported by: jsp

Component: porting

CC: 

Report Upstream: N/A

Authors: Jaap Spies

Dependencies: 

Work issues: 

Reviewers: David Kirkby

Merged in: sage-4.3.2.alpha1

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/8057/boehm_gc-7.1.p3.patch">boehm_gc-7.1.p3.patch: </a> by jsp at 20100126T17:24:39</li></ol>
