### PR TITLE
[with patch, positive review] Fix readline build on FreeBSD

### DIFF
--- a/build/pkgs/readline/SPKG.txt
+++ b/build/pkgs/readline/SPKG.txt
@@ -27,6 +27,9 @@ Website: http://tiswww.case.edu/php/chet/readline/rltop.html
  * Deleted some files from the doc directory from the standard distro, since it took tons of space; didn't delete anything else.
  * Work around some MacOSX dynamic lib flags
 
+=== readline-5.2.p7 (Mike Hansen, June 19th, 2009) ===
+ * Applied Peter Jeremy's fix from #5874.
+
 === readline-5.2.p6 (Michael Abshoff, February 2nd, 2009) ===
  * Deal with 64 bit OpenSUSE 11.1 (#4946)
 

--- a/build/pkgs/readline/spkg-install
+++ b/build/pkgs/readline/spkg-install
@@ -70,6 +70,8 @@ elif [ $UNAME = "CYGWIN" ]; then
   DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.dll.a
 elif [ "$UNAME" = "OpenBSD" ]; then
   DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.so.5.2
+elif [ "$UNAME" = "FreeBSD" ]; then
+  DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.so.5
 else
   DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.so
 fi
@@ -90,6 +92,10 @@ if [ -f $DYLIB_NAME -a -f $SAGE_LOCAL/lib/libreadline.a ]; then
   # Fix permissions.
   chmod 755 $SAGE_LOCAL/lib/libreadline.*
   chmod 755 $SAGE_LOCAL/lib/libhistory.*
+  if [ "$UNAME" = "FreeBSD" ]; then
+    ln -s libreadline.so.5 $SAGE_LOCAL/lib/libreadline.so
+    ln -s libhistory.so.5 $SAGE_LOCAL/lib/libhistory.so
+  fi
   exit 0
 else
   echo "Readline's build claims to have finished, but files that should have been built weren't."


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/5874">trac #5874</a>.

Reported by: pjeremy

Component: FreeBSD

CC: chet.ramey@case.edu

Report Upstream: 

Authors: Peter Jeremy

Dependencies: 

Work issues: 

Reviewers: Mike Hansen

Merged in: sage-4.1.rc0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/5874/readline-5.2.p6.patch">readline-5.2.p6.patch: </a> by pjeremy at 20090423T08:48:23</li></ol>
