### PR TITLE
[with patch, positive review] Fix freetype build on systems where make is not GNU make.

### DIFF
--- a/build/pkgs/freetype/SPKG.txt
+++ b/build/pkgs/freetype/SPKG.txt
@@ -3,6 +3,9 @@ MAINTAINER:
 
 == Releases ==
 
+=== freetype-2.3.5.p1 (Mike Hansen, June 19th, 2009) ===
+ * Applied Peter Jeremy's fix from #5866.
+
 === freetype-2.3.5.p0 (Michael Abshoff, May 18th, 2008) ===
  * add OSX 64 bit build support
 

--- a/build/pkgs/freetype/spkg-install
+++ b/build/pkgs/freetype/spkg-install
@@ -14,19 +14,19 @@ fi
 
 cd src
 
-./configure --prefix="$SAGE_LOCAL"
+GNUMAKE=${MAKE} ./configure --prefix="$SAGE_LOCAL"
 
 if [ $? -ne 0 ]; then
     exit 1;
 fi;
 
-make
+${MAKE}
 
 if [ $? -ne 0 ]; then
     exit 1;
 fi;
 
-make install
+${MAKE} install
 
 if [ $? -ne 0 ]; then
     exit 1;


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/5866">trac #5866</a>.

Reported by: pjeremy

Component: FreeBSD

CC: 

Report Upstream: N/A

Authors: Peter Jeremy

Dependencies: 

Work issues: 

Reviewers: Mike Hansen

Merged in: sage-4.1.rc0

Attachments: <ol><li><a href="http://trac.sagemath.org/sage_trac/attachment/ticket/5866/freetype-2.3.5.p0.patch">freetype-2.3.5.p0.patch: </a> by pjeremy at 20090423T06:53:28</li></ol>
