### PR TITLE
[with spkg, positive review] readline on opensuse11 64-bit still doesn't work

### DIFF
--- a/build/pkgs/readline/SPKG.txt
+++ b/build/pkgs/readline/SPKG.txt
@@ -27,6 +27,9 @@ Website: http://tiswww.case.edu/php/chet/readline/rltop.html
  * Deleted some files from the doc directory from the standard distro, since it took tons of space; didn't delete anything else.
  * Work around some MacOSX dynamic lib flags
 
+=== readline-5.2.p6 (Michael Abshoff, February 2nd, 2009) ===
+ * Deal with 64 bit OpenSUSE 11.1 (#4946)
+
 === readline-5.2.p5 (Michael Abshoff, January 5th, 2009) ===
  * Deal with OpenSUSE 11.1 (#4843)
 

--- a/build/pkgs/readline/spkg-install
+++ b/build/pkgs/readline/spkg-install
@@ -28,7 +28,11 @@ if [ `grep 11.1 /etc/SuSE-release > /dev/null; echo $?` == 0 ]; then
     echo "OpenSUSE 11.1 detected"
     if [ -d /usr/include/readline/ ]; then
         echo "The development version of libreadline is installed -> copying"
-        cp /lib/libreadline.so.* $SAGE_LOCAL/lib
+        if [ `uname -p` = "x86_64" ]; then
+            cp /lib64/libreadline.so.* $SAGE_LOCAL/lib
+        else
+            cp /lib/libreadline.so.* $SAGE_LOCAL/lib
+        fi
         cp -r /usr/include/readline  $SAGE_LOCAL/include
         exit 0
     else
@@ -73,7 +77,11 @@ fi
 if [ $OVERWRITE_READLINE == "true" ]; then
   echo "Overwriting libreadline.so.5.2 with the system one"
   rm -f $SAGE_LOCAL/lib/libreadline.so.5.2
-  cp /lib/libreadline.so.5.2 $SAGE_LOCAL/lib/
+  if [ `uname -p` = "x86_64" ]; then
+    cp /lib64/libreadline.so.5.2 $SAGE_LOCAL/lib
+  else
+    cp /lib/libreadline.so.5.2 $SAGE_LOCAL/lib
+   fi
 fi
 
 # Make sure that the install worked, despite whatever the error


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/4946">trac #4946</a>.

On opensuse64 (a sage.math vmware machine):

```
Overwriting libreadline.so.5.2 with the system one
cp: cannot stat `/lib/libreadline.so.5.2': No such file or directory
Readline's build claims to have finished, but files that should have been built weren't.

real    3m23.513s
user    0m15.741s
sys     0m23.429s
sage: An error occurred while installing readline-5.2.p5
Please email sage-devel http://groups.google.com/group/sage-devel
explaining the problem and send the relevant part of
of /home/wstein/build/opensuse64/build/sage-3.2.3/install.log.  Describe your computer, operating system, etc.
If you want to try to fix the problem, yourself *don't* just cd to
/home/wstein/build/opensuse64/build/sage-3.2.3/spkg/build/readline-5.2.p5 and type 'make'.
Instead type "/home/wstein/build/opensuse64/build/sage-3.2.3/sage -sh"
in order to set all environment variables correctly, then cd to
/home/wstein/build/opensuse64/build/sage-3.2.3/spkg/build/readline-5.2.p5
(When you are done debugging, you can type "exit" to leave the
subshell.)
make[1]: *** [installed/readline-5.2.p5] Error 1
make[1]: Leaving directory `/home/wstein/build/opensuse64/build/sage-3.2.3/spkg'

real    4m7.156s
user    0m16.409s
sys     0m23.905s
. local/bin/sage-env && sage-starts && sage-maketest
Testing that Sage starts...
/usr/bin/env: sage.bin: No such file or directory
Traceback (most recent call last):
  File "/home/wstein/build/opensuse64/build/sage-3.2.3/local/bin/sage-eval", line 4, in <module>
    from sage.all import *
ImportError: No module named sage.all
Sage failed to startup.
make: *** [check] Error 1
wstein@opensuse64:~/build/opensuse64$ 
```

Reported by: was

Component: build

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
