### PR TITLE
[with spkg; positive review] Fix readline related build problems on OpenSUSE 11.1

### DIFF
--- a/build/pkgs/readline/SPKG.txt
+++ b/build/pkgs/readline/SPKG.txt
@@ -22,5 +22,4 @@ FIXME
  * set correct permissions on libreadline.so* and libhistory.so* (#1752)
 
 === readline-5.2 ===
-
-FIXME
+ * changes lost to history - please let us know if you have any details.

--- a/build/pkgs/readline/spkg-install
+++ b/build/pkgs/readline/spkg-install
@@ -15,6 +15,28 @@ if [ `uname` = "Darwin" -a "$SAGE64" = "yes" ]; then
    LDFLAGS="-m64"
 fi
 
+echo "Deleting old readline headers and libs"
+rm -rf $SAGE_LOCAL/include/readline/
+rm -rf $SAGE_LOCAL/lib/libreadline.*
+
+OVERWRITE_READLINE=false; export OVERWRITE_READLINE
+
+# First we check for OpenSUSE 11.1 since bash is linked dynamically with a
+# readline that breaks when we build Sage's readline, so we work around this
+# for now
+if [ `grep 11.1 /etc/SuSE-release > /dev/null; echo $?` == 0 ]; then
+    echo "OpenSUSE 11.1 detected"
+    if [ -d /usr/include/readline/ ]; then
+        echo "The development version of libreadline is installed -> copying"
+        cp /lib/libreadline.so.* $SAGE_LOCAL/lib
+        cp -r /usr/include/readline  $SAGE_LOCAL/include
+        exit 0
+    else
+        echo "No headers found, building library"
+        OVERWRITE_READLINE="true"; export OVERWRITE_READLINE
+    fi
+fi
+
 cd src/
 
 build()
@@ -46,6 +68,13 @@ elif [ "$UNAME" = "OpenBSD" ]; then
   DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.so.5.2
 else
   DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.so
+fi
+
+if [ $OVERWRITE_READLINE == "true" ]; then
+  echo "Overwriting libreadline with the system one in three seconds"
+  sleep 3
+  rm -f $SAGE_LOCAL/lib/libreadline.so.5.2
+  cp /lib/libreadline.so.5.2 $SAGE_LOCAL/lib/
 fi
 
 # Make sure that the install worked, despite whatever the error


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/4843">trac #4843</a>.

There are some small issues with Sage's readline and the one from OpenSUSE not playing well together. I have some temporary fix to get around this.

Cheers,

Michael

Reported by: mabshoff

Component: packages

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
