### PR TITLE
[with spkg; positive review] change genus2reduction to include GPL copyright file and email from liu making the program GPL'd

### DIFF
--- a/build/pkgs/genus2reduction/SPKG.txt
+++ b/build/pkgs/genus2reduction/SPKG.txt
@@ -9,6 +9,9 @@ the place to fix it.
 
 == Releases ==
 
+=== genus2reduction-0.3.p4 (William Stein, December 8th, 2008) ===
+ * change genus2reduction to include GPL copyright file and email from liu making the program GPL'd (#4743)
+
 === genus2reduction-0.3.p3 (Michael Abshoff, May 18th, 2008) ===
  * add 64 bit OSX support
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/4743">trac #4743</a>.

The new spkg is here:

  http://sage.math.washington.edu/home/was/patches/genus2reduction-0.3.p4.spkg

I am upstream for this program.  I modified the src/ subdirectory to include the GPL COPYING file, along with an email Liu sent me where he officially GPL'd genus2reduction. 

This change was caused by a request from Karl Meyer who is packaging sage for Fedora. 

Reported by: was

Component: packages

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
