### PR TITLE
spkg-[install|check] should verify that SAGE_LOCAL is defined

### DIFF
--- a/build/pkgs/scons/SPKG.txt
+++ b/build/pkgs/scons/SPKG.txt
@@ -29,6 +29,7 @@ If Intel's ifort is installed a broken linker flag is added. Hence we copy over 
 === scons-0.97.0d20071212 (Michael Abshoff, March 24th, 2008) ===
  * update to latest 0.97 snapshot release
  * remove "-no_archive" from ifort.py (#1618)
+ * make sure SAGE_LOCAL is defined (#633)
 
 === scons-0.97 (Joel B. Mohler) ===
  * initial version

--- a/build/pkgs/scons/spkg-install
+++ b/build/pkgs/scons/spkg-install
@@ -1,8 +1,16 @@
 #!/bin/sh
 
+if [ "$SAGE_LOCAL" = "" ]; then
+   echo "SAGE_LOCAL undefined ... exiting";
+   echo "Maybe run 'sage -sh'?"
+   exit 1
+fi
+
 cd src/
 
 cp ../patch/ifort.py engine/SCons/Tool
+
+rm -rf $SAGE_LOCAL/lib/scons-0.97
 
 python setup.py install
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/633">trac #633</a>.

When building spkgs manually by invoking spkg-install on the shell I oftern do not have sage-env sourced. Consequently odd things happen:

```
[mabshoff@m940 mpfr-2.2.1.p1]$ ./spkg-install
./spkg-install: line 16: [: =: unary operator expected
```

We ought to verify that at least SAGE_LOCAL is non-empty. If it is empty print a warning message and exit.

To fix this we need to touch every spkg-install in the tree which is more that 75 scripts. So while we are at it we should also add spkg-check scripts to each spkg while we are at it.

Cheers,

Michael

Reported by: mabshoff

Component: packages

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
