### PR TITLE
[with spkg, positive review] Make SCons ignore Intel ifort's linker options

### DIFF
--- a/build/pkgs/scons/SPKG.txt
+++ b/build/pkgs/scons/SPKG.txt
@@ -1,1 +1,34 @@
-scons-0.97 SPKG
+= SCons =
+
+== Description ==
+
+SCons is an Open Source software construction tool—that is, a next-generation build tool. Think of SCons as an improved, cross-platform substitute for the classic Make utility with integrated functionality similar to autoconf/automake and compiler caches such as ccache. In short, SCons is an easier, more reliable and faster way to build software.
+
+Website: http://www.scons.org/
+
+== License ==
+
+X/MIT
+
+== SPKG Maintainers ==
+ * Michael Abshoff
+ * Joel B. Mohler
+
+== Upstream Contact ==
+ * SCons mailing lists - see http://www.scons.org/lists.php
+
+== Dependencies ==
+ * Python
+
+== Special Update/Build Instructions ==
+
+If Intel's ifort is installed a broken linker flag is added. Hence we copy over an ifort.py with that flag removed.
+
+== Changelog ==
+
+=== scons-0.97.0d20071212 (Michael Abshoff, March 24th, 2008) ===
+ * update to latest 0.97 snapshot release
+ * remove "-no_archive" from ifort.py (#1618)
+
+=== scons-0.97 (Joel B. Mohler) ===
+ * initial version

--- a/build/pkgs/scons/patch/ifort.py
+++ b/build/pkgs/scons/patch/ifort.py
@@ -1,0 +1,73 @@
+"""SCons.Tool.ifort
+
+Tool-specific initialization for newer versions of the Intel Fortran Compiler
+for Linux.
+
+There normally shouldn't be any need to import this module directly.
+It will usually be imported through the generic SCons.Tool.Tool()
+selection method.
+
+"""
+
+#
+# Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007 The SCons Foundation
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+
+__revision__ = "src/engine/SCons/Tool/ifort.py 2523 2007/12/12 09:37:41 knight"
+
+import string
+
+import SCons.Defaults
+
+import fortran
+
+def generate(env):
+    """Add Builders and construction variables for ifort to an Environment."""
+    # ifort supports Fortran 90 and Fortran 95
+    # Additionally, ifort recognizes more file extensions.
+    SCons.Tool.SourceFileScanner.add_scanner('.i', fortran.FortranScan)
+    SCons.Tool.SourceFileScanner.add_scanner('.i90', fortran.FortranScan)
+    fortran.FortranSuffixes.extend(['.i', '.i90'])
+    fortran.generate(env)
+
+    env['_FORTRAND'] = 'ifort'
+
+    # If files are compiled into objects, the Intel Fortran Compiler must use
+    # ld to link shared libraries.
+    env['SHLINK'] = 'ld'
+
+    # Additionally, no symbols can be defined in an archive file; to use
+    # Intel Fortran to create shared libraries, all external symbols must
+    # be in shared libraries.
+    env['SHLINKFLAGS'] = '-shared'
+
+    #
+    if env['PLATFORM'] == 'win32':
+        # On Windows, the ifort compiler specifies the object on the
+        # command line with -object:, not -o.  Massage the necessary
+        # command-line construction variables.
+        for var in ['_FORTRANCOMD', '_FORTRANPPCOMD',
+                    '_SHFORTRANCOMD', '_SHFORTRANPPCOMD']:
+            env[var] = string.replace(env[var], '-o $TARGET', '-object:$TARGET')
+
+def exists(env):
+    return env.Detect('ifort')

--- a/build/pkgs/scons/spkg-install
+++ b/build/pkgs/scons/spkg-install
@@ -2,6 +2,8 @@
 
 cd src/
 
+cp ../patch/ifort.py engine/SCons/Tool
+
 python setup.py install
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/1618">trac #1618</a>.

In http://groups.google.com/group/sage-devel/t/74de10c9f2d3edf7 Francois reported:

```
Hello Michael,

I think I found my problem. A little googling actually helped with
this link:
http://bugs.archlinux.org/task/6864
I did some experiments with the intel _fortran_ compiler (not even the
C compiler)
and I still have it on my system.
Since the intel compiler doesn't compile my lattice QCD code correctly
anyway
I will remove it and try again.
I am busy for the next few hours so I will do that a bit latter.

Thanks for looking,
Francois
```

Cheers,

Michael

Reported by: mabshoff

Component: packages

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
