### PR TITLE
[with link to spkg, positive review] readline currently not building dynamic library on Mac

### DIFF
--- a/build/pkgs/readline/SPKG.txt
+++ b/build/pkgs/readline/SPKG.txt
@@ -5,6 +5,10 @@ didn't delete anything else.
 
 FIXME
 
+=== readline-5.2.p1 (Craig Citro) ===
+ * add fix for OSX 10.5 from Pari FAQ, where readline wasn't building
+ a dynamic library
+
 === readline-5.2.p0 (Michael Abshoff) ===
  * set correct permissions on libreadline.so* and libhistory.so* (#1752)
 

--- a/build/pkgs/readline/spkg-install
+++ b/build/pkgs/readline/spkg-install
@@ -8,12 +8,25 @@ cd src/
 build()
 {
     ./configure --prefix=$SAGE_LOCAL
+    if [ `uname` == 'Darwin' ]; then
+      if [ `uname -r | awk -F. '{ print $1; }'` == '9' ]; then
+	echo "Fixing Makefile for OSX 10.5 compatibility"
+	sed -e 's/-dynamic/-dynamiclib/' shlib/Makefile > shlib/Makefile.ok
+	mv shlib/Makefile.ok shlib/Makefile
+      fi
+    fi
     make install
 }
 
 build
 
-if [ -f $SAGE_LOCAL/lib/libreadline.so -o -f $SAGE_LOCAL/lib/libreadline.a ]; then
+if [ `uname` == 'Darwin' ]; then
+  DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.dylib
+else
+  DYLIB_NAME=$SAGE_LOCAL/lib/libreadline.so
+fi
+
+if [ -f $DYLIB_NAME -a -f $SAGE_LOCAL/lib/libreadline.a ]; then
   chmod 755 $SAGE_LOCAL/lib/libreadline.*
   chmod 755 $SAGE_LOCAL/lib/libhistory.*
   exit 0


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/2282">trac #2282</a>.

Currently, readline fails to build a dynamic library on Mac, and the sage installer doesn't notice this at all. Once this happens, other things (notably Pari) can't find readline, and know not to build against the system-wide fake readline (Mac ships a pseudo-readline for licensing reasons). Pari then doesn't have readline support, and is annoying to use. Luckily, there was a fix on the [http://www.ufr-mi.u-bordeaux.fr/~belabas/pari/doc/faq.html#mac10readline:Pari FAQ], which I've added to our spkg-install for readline when we're on a Mac. 

So there are really two things I've changed:
- Add the fix for building readline (this involves changing `dynamic` to 
  `dynamiclib` in the generated Makefile)
- Change `-o` to `-a` in `spkg-install`: this is why we weren't noticing that
  readline failed to build.

Of course, I don't know why it was `-o` instead of `-a` in the first place: if there was a good reason for that, someone should let me know and I'll change it back in the non-Mac case.

Reported by: craigcitro

Component: packages

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
