### PR TITLE
[with spkg, with positive review] sage-2.10.2.alpha1 -- genus2reduction is now completely broken (maybe caused by new spkg with makefile?)

### DIFF
--- a/build/pkgs/genus2reduction/SPKG.txt
+++ b/build/pkgs/genus2reduction/SPKG.txt
@@ -4,3 +4,9 @@ MAINTAINER:
 This is the home of genus2reduction, so there isn't an auxiliary download
 cite for updates.  If building this breaks because PARI changes, this is
 the place to fix it.
+
+======= William Stein (2008-02-21) ================
+   * Put -lgmp -lm *back* in the build line.  Tim Abbot had removed them claiming they aren't
+     needed, but that's not correct.  They are needed, since, e.g., pari relies on them.
+     Maybe they aren't needed on LInux for some reason, but on OS X they definitely are.
+     Please don't remove them again.

--- a/build/pkgs/genus2reduction/spkg-install
+++ b/build/pkgs/genus2reduction/spkg-install
@@ -5,7 +5,7 @@ echo "Compiling genus2reduction.c"
 cd src/
 
 $CC $CFLAGS -O2 -I"$SAGE_LOCAL/include/pari" -L"$SAGE_LOCAL/lib" \
-                -o genus2reduction genus2reduction.c -lpari
+                -o genus2reduction genus2reduction.c -lpari -lgmp -lm
 
 if [ $? -ne 0 ]; then
     echo "Error building genus2reduction"


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/2225">trac #2225</a>.

I think Tim (the Debian guy) wrote a makefile for genus2reduction.  He possibly messed something up, since now it's completely broken:

```
sage -t  devel/sage-main/sage/interfaces/genus2reduction.py **********************************************************************
File "genus2reduction.py", line 197:
    sage: R = genus2reduction(x^3 - 2*x^2 - 2*x + 1, -5*x^5)
Exception raised:
    Traceback (most recent call last):
      File "/Users/was/build/sage-2.10.2.alpha1/local/lib/python2.5/doctest.py", line 1212, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.example_2[1]>", line 1, in <module>
        R = genus2reduction(x**Integer(3) - Integer(2)*x**Integer(2) - Integer(2)*x + Integer(1), -Integer(5)*x**Integer(5))###line 197:
    sage: R = genus2reduction(x^3 - 2*x^2 - 2*x + 1, -5*x^5)
      File "/Users/was/build/sage-2.10.2.alpha1/local/lib/python2.5/site-packages/sage/interfaces/genus2reduction.py", line 358, in __call__
        s, Q, P = self.raw(Q, P)
      File "/Users/was/build/sage-2.10.2.alpha1/local/lib/python2.5/site-packages/sage/interfaces/genus2reduction.py", line 349, in raw
        raise ValueError, "error in input; possibly singular curve? (Q=%s, P=%s)"%(Q,P)
    ValueError: error in input; possibly singular curve? (Q=x^3 - 2*x^2 - 2*x + 1, P=-5*x^5)
**********************************************************************
File "genus2reduction.py", line 198:
    sage: R.conductor
Exception raised:
    Traceback (most recent call last):
      File "/Users/was/build/sage-2.10.2.alpha1/local/lib/python2.5/doctest.py", line 1212, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.example_2[2]>", line 1, in <module>
        R.conductor###line 198:
    sage: R.conductor
    NameError: name 'R' is not defined
**********************************************************************
File "genus2reduction.py", line 200:
    sage: factor(R.conductor)
Exception raised:
    Traceback (most recent call last):
      File "/Users/was/build/sage-2.10.2.alpha1/local/lib/python2.5/doctest.py", line 1212, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.example_2[3]>", line 1, in <module>
        factor(R.conductor)###line 200:
    sage: factor(R.conductor)
    NameError: name 'R' is not defined
*
...
```

Reported by: was

Component: number theory

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
