### PR TITLE
[with spkg] crap -- networkx spkg in sage-2.10.1.rc3 contains a bunch of .svn directorie

### DIFF
--- a/build/pkgs/networkx/SPKG.txt
+++ b/build/pkgs/networkx/SPKG.txt
@@ -1,5 +1,8 @@
 = networkx-0.36 =
 
+=== networkx-0.36.p1 (Michael Abshoff, Jan. 31st, 2008) ===
+ * remove .svn directories (#2009)
+
 === networkx-0.36.p0 ===
  * add hg repo, check in files
 


### PR DESCRIPTION
Imported from <a href="http://trac.sagemath.org/sage_trac/ticket/2009">trac #2009</a>.

```
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/scripts/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/tests/readwrite/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/tests/generators/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/tests/drawing/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/tests/data/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/tests/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/readwrite/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/generators/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/drawing/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/networkx/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/doc/NEP/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/doc/examples/.svn
sage-2.10.1.rc3/spkg/standard/networkx-0.36.p0/src/doc/.svn
```

Reported by: was

Component: packages

CC: 

Report Upstream: 

Authors: ?

Dependencies: 

Work issues: 

Reviewers: 

Merged in: 

Attachments: <ol></ol>
